### PR TITLE
Queries compatible ACLO URL

### DIFF
--- a/lib/saml_idp/default.rb
+++ b/lib/saml_idp/default.rb
@@ -127,7 +127,7 @@ EOS
       cert: SERVICE_PROVIDER_CERT,
       fingerprint: SP_FINGERPRINT,
       acs_url: 'http://localhost:3000/saml/consume',
-      sso_url: 'http://localhost:3000/saml/sso_return',
+      assertion_consumer_logout_service_url: 'http://localhost:3000/saml/sso_return',
       block_encryption: 'aes256-cbc',
       key_transport: 'rsa-oaep-mgf1p',
     }

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -38,7 +38,7 @@ module SamlIdp
 
     def response_url
       return service_provider.acs_url if xpath("//samlp:AuthnRequest", samlp: samlp).first.present?
-      return service_provider.sso_url if xpath("//samlp:LogoutRequest", samlp: samlp).first.present?
+      return service_provider.assertion_consumer_logout_service_url if xpath("//samlp:LogoutRequest", samlp: samlp).first.present?
       return nil
     end
 

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -10,7 +10,7 @@ module SamlIdp
     attribute :fingerprint
     attribute :identifier
     attribute :metadata_url
-    attribute :sso_url
+    attribute :assertion_consumer_logout_service_url
     attribute :validate_signature
 
     delegate :config, to: :SamlIdp

--- a/spec/lib/saml_idp/service_provider_spec.rb
+++ b/spec/lib/saml_idp/service_provider_spec.rb
@@ -6,12 +6,14 @@ module SamlIdp
 
     it { should respond_to :fingerprint }
     it { should respond_to :metadata_url }
+    it { should respond_to :assertion_consumer_logout_service_url }
     it { should_not be_valid }
 
     describe "with attributes" do
       let(:attributes) { { fingerprint: fingerprint, metadata_url: metadata_url } }
       let(:fingerprint) { Default::SP_FINGERPRINT }
       let(:metadata_url) { "http://localhost:3000/metadata" }
+      let(:assertion_consumer_logout_service_url) { 'http://localhost:3000/saml/logout' }
 
       it "has a valid fingerprint" do
         subject.fingerprint.should == fingerprint


### PR DESCRIPTION
Removes extraneous "sso_url" since the attribute already existed.