### PR TITLE
use Base64.strict_encode64 to avoid newlines and other whitespace

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -101,7 +101,7 @@ module SamlIdp
     end
     
     def encode_response(principal, opts = {})
-      Base64.encode64(response_doc(principal, opts).to_xml)
+      Base64.strict_encode64(response_doc(principal, opts).to_xml)
     end
 
     def relay_state

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -52,6 +52,8 @@ describe SamlIdp::Controller do
 
     it "should create an Encrypted, signed SAML Response" do
       saml_response = encode_response(principal)
+      expect(saml_response).to_not match(/\s/)
+
       response = OneLogin::RubySaml::Response.new(
         saml_response,
         { private_key: SamlIdp::Default::SERVICE_PROVIDER_KEY })


### PR DESCRIPTION
Per the rdoc, `Base64.encode64()`:
> This method complies with RFC 2045. Line feeds are added to every 60 encoded characters.

while `Base64.strict_encode64()`:
> This method complies with RFC 4648. No line feeds are added.

The line feeds (and more precisely, the leading whitespace padding on each new line) causes this regex to break:

`BASE64_FORMAT = %r(\A[A-Za-z0-9+/]{4}*[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=?\Z)`

(from https://github.com/onelogin/ruby-saml/blob/master/lib/onelogin/ruby-saml/saml_message.rb#L22)

Presumably that regex conforms to RFC 4648.

Because the regex breaks, the SAML payload is not decoded and all sorts of havoc ensues.