### PR TITLE
Rspec upgrade -> 3.x

### DIFF
--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "rspec", "~> 3"
+  s.add_development_dependency "rspec-rails", "~> 3"
+  s.add_development_dependency 'test-unit', '~> 3.0'
 #  s.add_development_dependency('nokogiri-xmlsec-me-harder', "~> 0.9")
 #  s.add_development_dependency "ruby-saml", "~> 0.8"
   s.add_development_dependency("rails", "~> 3.2")

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -2,8 +2,6 @@
 require 'spec_helper'
 require 'saml_idp/logout_request_builder'
 
-SamlIdp.config.base_saml_location = 'http://example.com'
-
 class MySamlController < ApplicationController
   include SamlIdp::Controller
 

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -2,44 +2,58 @@
 require 'spec_helper'
 require 'saml_idp/logout_request_builder'
 
-describe SamlIdp::Controller do
+SamlIdp.config.base_saml_location = 'http://example.com'
+
+class MySamlController < ApplicationController
   include SamlIdp::Controller
+
+  def test_saml_request
+    validate_saml_request
+    if self.saml_request
+      #puts self.saml_request.raw_xml
+      #puts self.saml_request.pretty_inspect
+    end
+    if valid_saml_request?
+      render nothing: true, status: :ok
+    end
+  end
+
+  def test_saml_response
+    saml_response_url
+  end
+
+  def test_encode_response(payload)
+    encode_response(payload)
+  end
+
+  def test_response_doc(payload)
+    response_doc(payload)
+  end
+end
+
+describe MySamlController, type: :controller do
+
+  before do
+    routes.draw {
+      get 'test_saml_request' => 'my_saml#test_saml_request'
+      post 'test_saml_request' => 'my_saml#test_saml_request'
+    }
+  end
 
   XMLDSIG_RSA_SHA256_URI = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
   XMLENC_SHA256_URI = 'http://www.w3.org/2001/04/xmlenc#sha256'
 
-  def render(*)
-  end
-
-  def params
-    @params ||= {}
-  end
-
-  class MockRequest
-    attr_accessor :request_method, :url
-    def initialize(method='GET', url='http://example.com')
-      @request_method = method
-      @url = url
-    end
-  end
-
-  def request
-    @request ||= MockRequest.new
-  end
-
   it "should find the SAML ACS URL" do
     pending("Should this allow for non-metadata specified URLs?")
     requested_saml_acs_url = "https://example.com/saml/consume"
-    params[:SAMLRequest] = make_saml_request(requested_saml_acs_url)
-    validate_saml_request
-    saml_response_url.should == requested_saml_acs_url
+    saml_request = make_saml_request(requested_saml_acs_url)
+    get :test_saml_request, { SAMLRequest: saml_request }
+    expect(subject.test_saml_response).to eq(requested_saml_acs_url)
   end
 
   context "SAML Responses" do
     before(:each) do
-      # TODO(awong): Test POST.
-      params[:SAMLRequest] = make_saml_request
-      validate_saml_request
+      get :test_saml_request, { SAMLRequest: make_saml_request }
     end
 
     let(:principal) { double email_address: "foo@example.com" }
@@ -51,17 +65,18 @@ describe SamlIdp::Controller do
     end
 
     it "should create an Encrypted, signed SAML Response" do
-      saml_response = encode_response(principal)
+      saml_response = subject.test_encode_response(principal)
       expect(saml_response).to_not match(/\s/)
 
-      response = OneLogin::RubySaml::Response.new(
+      rubysaml_response = OneLogin::RubySaml::Response.new(
         saml_response,
-        { private_key: SamlIdp::Default::SERVICE_PROVIDER_KEY })
-      response.name_id.should == "foo@example.com"
-      response.issuer.should == "http://example.com"
-      response.settings = saml_settings
-      response.is_valid?.should be_truthy
-      nokogiri_doc = Nokogiri::XML(response.document.to_s)
+        { private_key: SamlIdp::Default::SERVICE_PROVIDER_KEY }
+      )
+      expect(rubysaml_response.name_id).to eq("foo@example.com")
+      expect(rubysaml_response.issuer).to eq("http://example.com")
+      rubysaml_response.settings = saml_settings
+      expect(rubysaml_response.is_valid?).to be_truthy
+      nokogiri_doc = Nokogiri::XML(rubysaml_response.document.to_s)
       signature_method_nodeset = nokogiri_doc.xpath(
         '//samlp:Response/saml:Assertion/ds:Signature/ds:SignedInfo/ds:SignatureMethod',
         samlp: Saml::XML::Namespaces::PROTOCOL,
@@ -118,21 +133,21 @@ describe SamlIdp::Controller do
 
   context "Single Logout" do
     before(:each) do
-      params[:SAMLRequest] = Base64.encode64(SamlIdp::LogoutRequestBuilder.new(
+      saml_request = Base64.strict_encode64(SamlIdp::LogoutRequestBuilder.new(
         '_response_id',
         'localhost:3000',
         'http://localhost:1337/saml/logout',
         'himom',
         'some_qualifier',
         'abc123index',
-        signature_opts).build.to_xml)
-      @request = MockRequest.new('POST')
-      validate_saml_request
+        subject.signature_opts).build.to_xml
+      )
+      post :test_saml_request, { SAMLRequest: saml_request }
     end
 
     it "should generate a signed LogoutResponse to the request" do
-      signed_doc = Saml::XML::Document.parse(response_doc(nil).to_xml)
-      cert = OpenSSL::X509::Certificate.new(self.signature_opts[:cert])
+      signed_doc = Saml::XML::Document.parse(subject.test_response_doc(nil).to_xml)
+      cert = OpenSSL::X509::Certificate.new(subject.signature_opts[:cert])
       fingerprint = OpenSSL::Digest::SHA256.new(cert.to_der).hexdigest
       expect(signed_doc.signed?).to be_truthy
       expect(signed_doc.valid_signature?(fingerprint)).to be_truthy

--- a/spec/lib/saml_idp/metadata_builder_spec.rb
+++ b/spec/lib/saml_idp/metadata_builder_spec.rb
@@ -12,6 +12,7 @@ module SamlIdp
     end
 
     it "has expected fields" do
+      SamlIdp.config.base_saml_location = nil
       # Rip the assertion into a separate doc for more stabe comparisons.
       generated_doc = subject.build
       expected_doc = Nokogiri::XML(fixture("metadata.xml"))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ STDERR.puts("Running Specs under Ruby Version #{RUBY_VERSION}")
 require "rails_app/config/environment"
 
 require 'rspec'
+require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/rails'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,8 @@ RSpec.configure do |config|
 
   config.before do
     SamlIdp.configure do |c|
+      c.base_saml_location = 'http://example.com'
+
       c.attributes = {
         emailAddress: {
           name: "email-address",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,10 @@ RSpec.configure do |config|
   config.mock_with :rspec
   config.order = "random"
 
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+
   config.include RSpec::XSD
   config.include SamlRequestMacros
   config.include SecurityHelpers


### PR DESCRIPTION
Refactor tests to match rspec 3.x syntax, including overhaul of the controller tests to use `rspec-rails` gem and associated helpers. This allows us to test the full request/response cycle.