### PR TITLE
Request requires not-nil Issuer

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -115,10 +115,11 @@ module SamlIdp
     end
 
     def service_provider?
-      service_provider.valid?
+      service_provider && service_provider.valid?
     end
 
     def service_provider
+      return unless issuer.present?
       @_service_provider ||= ServiceProvider.new((service_provider_finder[issuer] || {}).merge(identifier: issuer))
     end
 

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -66,6 +66,7 @@ module SamlIdp
         authn_request = described_class.new raw_req
         authn_request.issuer.should_not == ''
         authn_request.issuer.should == nil
+        authn_request.valid?.should == false
       end
     end
 


### PR DESCRIPTION
**Why**: The Request must have a not-nil Issuer in order to
look up a ServiceProvider.

Dupe PR as https://github.com/sportngin/saml_idp/pull/52
