### PR TITLE
XML security get params

### DIFF
--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -72,6 +72,7 @@ module Saml
       def options_have_signature(options)
         options[:get_params] && options[:get_params][:Signature]
       end
+      private :options_have_signature
 
       def valid_signature?(fingerprint, options = {})
         (signed? || options_have_signature(options)) &&

--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -69,9 +69,13 @@ module Saml
         !!xpath("//ds:Signature", ds: signature_namespace).first
       end
 
-      def valid_signature?(fingerprint)
-        signed? &&
-          signed_document.validate(fingerprint, :soft)
+      def options_have_signature(options)
+        options[:get_params] && options[:get_params][:Signature]
+      end
+
+      def valid_signature?(fingerprint, options = {})
+        (signed? || options_have_signature(options)) &&
+          signed_document.validate(fingerprint, :soft, options)
       end
 
       def signed_document

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -24,7 +24,7 @@ module SamlIdp
     end
 
     def decode_request(raw_saml_request)
-      self.saml_request = Request.from_deflated_request(raw_saml_request)
+      self.saml_request = Request.from_deflated_request(raw_saml_request, get_params: params)
     end
 
     def authn_context_classref

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -19,9 +19,9 @@ module SamlIdp
       attributes.present?
     end
 
-    def valid_signature?(doc, require_signature = false)
+    def valid_signature?(doc, require_signature = false, options = {})
       if require_signature || should_validate_signature?
-        doc.valid_signature?(fingerprint)
+        doc.valid_signature?(fingerprint, options.merge(cert: cert))
       else
         true
       end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -43,16 +43,27 @@ module SamlIdp
         extract_signed_element_id
       end
 
-      def validate(idp_cert_fingerprint, soft = true)
-        # get cert from response
+      def validate(idp_cert_fingerprint, soft = true, options = {})
         cert_element = REXML::XPath.first(self, "//ds:X509Certificate", { "ds"=>DSIG })
-        raise ValidationError.new("Certificate element missing in response (ds:X509Certificate)") unless cert_element
-        base64_cert  = cert_element.text
-        cert_text    = Base64.decode64(base64_cert)
-        cert         = OpenSSL::X509::Certificate.new(cert_text)
+        if cert_element
+          base64_cert = cert_element.text
+        elsif options[:cert]
+          if options[:cert].is_a?(String)
+            base64_cert = options[:cert]
+          elsif options[:cert].is_a?(OpenSSL::X509::Certificate)
+            base64_cert = Base64.encode64(options[:cert].to_pem)
+          else
+            raise ValidationError.new("options[:cert] must be Base64-encoded String or OpenSSL::X509::Certificate")
+          end
+        else
+          raise ValidationError.new("Certificate element missing in response (ds:X509Certificate) and not provided in options[:cert]")
+        end
+
+        cert_text = Base64.decode64(base64_cert)
+        cert      = OpenSSL::X509::Certificate.new(cert_text)
 
         # check cert matches registered idp cert
-        fingerprint = fingerprint_cert(cert)
+        fingerprint = fingerprint_cert(cert, options)
         sha1_fingerprint = fingerprint_cert_sha1(cert)
         plain_idp_cert_fingerprint = idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/,"").downcase
 
@@ -60,13 +71,20 @@ module SamlIdp
           return soft ? false : (raise ValidationError.new("Fingerprint mismatch"))
         end
 
-        validate_doc(base64_cert, soft)
+        validate_doc(base64_cert, soft, options)
       end
 
-      def fingerprint_cert(cert)
-        # pick algorithm based on the doc's digest algorithm
-        ref_elem = REXML::XPath.first(self, "//ds:Reference", {"ds"=>DSIG})
-        digest_algorithm = algorithm(REXML::XPath.first(ref_elem, "//ds:DigestMethod"))
+      def signature_algorithm(options)
+        if options[:get_params] && options[:get_params][:SigAlg]
+          algorithm(options[:get_params][:SigAlg])
+        else
+          ref_elem = REXML::XPath.first(self, "//ds:Reference", {"ds"=>DSIG})
+          algorithm(REXML::XPath.first(ref_elem, "//ds:DigestMethod"))
+        end
+      end
+
+      def fingerprint_cert(cert, options)
+        digest_algorithm = signature_algorithm(options)
         digest_algorithm.hexdigest(cert.to_der)
       end
 
@@ -74,9 +92,41 @@ module SamlIdp
         OpenSSL::Digest::SHA1.hexdigest(cert.to_der)
       end
 
-      def validate_doc(base64_cert, soft = true)
-        # validate references
+      def validate_doc(base64_cert, soft = true, options = {})
+        if options[:get_params]
+          validate_doc_params_signature(base64_cert, soft, options[:get_params])
+        else
+          validate_doc_embedded_signature(base64_cert, soft)
+        end
+      end
 
+      private
+
+      def request?
+        root.name != 'Response'
+      end
+
+      # matches RubySaml::Utils
+      def build_query(params)
+        type, data, relay_state, sig_alg = [:type, :data, :relay_state, :sig_alg].map { |k| params[k]}
+
+        url_string = "#{type}=#{CGI.escape(data)}"
+        url_string << "&RelayState=#{CGI.escape(relay_state)}" if relay_state
+        url_string << "&SigAlg=#{CGI.escape(sig_alg)}"
+      end
+
+      def validate_doc_params_signature(base64_cert, soft = true, params)
+        document_type = request? ? :SAMLRequest : :SAMLResponse
+        canon_string = build_query(
+          type: document_type,
+          data: params[document_type.to_sym],
+          relay_state: params[:RelayState],
+          sig_alg: params[:SigAlg]
+        )
+        verify_signature(base64_cert, params[:SigAlg], Base64.decode64(params[:Signature]), canon_string, soft)
+      end
+
+      def validate_doc_embedded_signature(base64_cert, soft = true)
         # check for inclusive namespaces
         inclusive_namespaces = extract_inclusive_namespaces
 
@@ -120,13 +170,15 @@ module SamlIdp
 
         base64_signature        = REXML::XPath.first(@sig_element, "//ds:SignatureValue", {"ds"=>DSIG}).text
         signature               = Base64.decode64(base64_signature)
+        sig_alg                 = REXML::XPath.first(signed_info_element, "//ds:SignatureMethod", {"ds"=>DSIG})
 
-        # get certificate object
-        cert_text               = Base64.decode64(base64_cert)
-        cert                    = OpenSSL::X509::Certificate.new(cert_text)
+        verify_signature(base64_cert, sig_alg, signature, canon_string, soft)
+      end
 
-        # signature method
-        signature_algorithm     = algorithm(REXML::XPath.first(signed_info_element, "//ds:SignatureMethod", {"ds"=>DSIG}))
+      def verify_signature(base64_cert, sig_alg, signature, canon_string, soft)
+        cert_text           = Base64.decode64(base64_cert)
+        cert                = OpenSSL::X509::Certificate.new(cert_text)
+        signature_algorithm = algorithm(sig_alg)
 
         unless cert.public_key.verify(signature_algorithm.new, signature, canon_string)
           return soft ? false : (raise ValidationError.new("Key validation error"))
@@ -134,8 +186,6 @@ module SamlIdp
 
         return true
       end
-
-      private
 
       def digests_match?(hash, digest_value)
         hash == digest_value
@@ -157,8 +207,11 @@ module SamlIdp
       end
 
       def algorithm(element)
-        algorithm = element.attribute("Algorithm").value if element
-        algorithm = algorithm && algorithm =~ /sha(.*?)$/i && $1.to_i
+        algorithm = element
+        if algorithm.is_a?(REXML::Element)
+          algorithm = element.attribute("Algorithm").value
+        end
+        algorithm = algorithm && algorithm =~ /(rsa-)?sha(.*?)$/i && $2.to_i
         case algorithm
         when 256 then OpenSSL::Digest::SHA256
         when 384 then OpenSSL::Digest::SHA384

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -19,13 +19,29 @@ module SamlRequestMacros
     request_builder.encoded
   end
 
+  def make_sp_logout_request(requested_saml_logout_url = 'https://foo.example.com/saml/logout')
+    settings = saml_settings.dup
+    settings.assertion_consumer_logout_service_url = requested_saml_logout_url
+    settings.name_identifier_value = 'some-user-id'
+    OneLogin::RubySaml::Logoutrequest.new.create(settings)
+  end
+
   def saml_settings(saml_acs_url = "https://foo.example.com/saml/consume")
     settings = OneLogin::RubySaml::Settings.new
     settings.assertion_consumer_service_url = saml_acs_url
     settings.issuer = "http://example.com/issuer"
     settings.idp_sso_target_url = "http://idp.com/saml/idp"
+    settings.idp_slo_target_url = "http://idp.com/saml/idp-slo"
     settings.idp_cert_fingerprint = SamlIdp::Default::FINGERPRINT
     settings.name_identifier_format = SamlIdp::Default::NAME_ID_FORMAT
+    settings.certificate = SamlIdp::Default::X509_CERTIFICATE
+    settings.private_key = SamlIdp::Default::SECRET_KEY
+    settings.security = {
+      embed_sign: false,
+      logout_requests_signed: true,
+      digest_method: 'http://www.w3.org/2001/04/xmlenc#sha256',
+      signature_method: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+    }
     settings
   end
 

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -48,7 +48,7 @@ module SamlIdp
       expect { document.validate("a fingerprint", false) }.to(
         raise_error(
           SamlIdp::XMLSecurity::SignedDocument::ValidationError,
-          "Certificate element missing in response (ds:X509Certificate)"
+          "Certificate element missing in response (ds:X509Certificate) and not provided in options[:cert]"
         )
       )
     end


### PR DESCRIPTION
The RubySaml lib supports signature validation via GET params as well as embedded within the XML document itself. This PR adds similar support, especially for Logout requests, where signature is necessary to prevent cross-site attacks.

dupe of https://github.com/sportngin/saml_idp/pull/50
