### PR TITLE
The cert does not need to be base64 decoded

### DIFF
--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -45,8 +45,7 @@ module SamlIdp
 
       def validate(idp_cert_fingerprint, soft = true, options = {})
         base64_cert = find_base64_cert(options)
-        cert_text   = Base64.decode64(base64_cert)
-        cert        = OpenSSL::X509::Certificate.new(cert_text)
+        cert        = OpenSSL::X509::Certificate.new(base64_cert)
 
         # check cert matches registered idp cert
         fingerprint = fingerprint_cert(cert, options)
@@ -179,8 +178,7 @@ module SamlIdp
       end
 
       def verify_signature(base64_cert, sig_alg, signature, canon_string, soft)
-        cert_text           = Base64.decode64(base64_cert)
-        cert                = OpenSSL::X509::Certificate.new(cert_text)
+        cert                = OpenSSL::X509::Certificate.new(base64_cert)
         signature_algorithm = algorithm(sig_alg)
 
         unless cert.public_key.verify(signature_algorithm.new, signature, canon_string)


### PR DESCRIPTION
The cert does not need to be base64 decoded

instead, pass the base64 encoded cert to create a new OpenSSL::X509::Certificate