### PR TITLE
Use head instead of render nothing: true

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -20,7 +20,7 @@ module SamlIdp
 
     def validate_saml_request(raw_saml_request = params[:SAMLRequest])
       decode_request(raw_saml_request)
-      render nothing: true, status: :forbidden unless valid_saml_request?
+      head :forbidden unless valid_saml_request?
     end
 
     def decode_request(raw_saml_request)

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -11,6 +11,9 @@ describe SamlIdp::Controller do
     @params ||= {}
   end
 
+  def head(status, options = {})
+  end
+
   it "should find the SAML ACS URL" do
     requested_saml_acs_url = "https://example.com/saml/consume"
     params[:SAMLRequest] = make_saml_request(requested_saml_acs_url)
@@ -111,4 +114,13 @@ describe SamlIdp::Controller do
     end
   end
 
+  context 'invalid SAML Request' do
+    it 'returns headers only with a forbidden status' do
+      params[:SAMLRequest] = make_invalid_saml_request
+
+      expect(self).to receive(:head).with(:forbidden)
+
+      validate_saml_request
+    end
+  end
 end

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -8,6 +8,12 @@ module SamlRequestMacros
     CGI.unescape(auth_url.split("=").last)
   end
 
+  def make_invalid_saml_request(requested_saml_acs_url = "https://foo.example.com/saml/consume")
+    auth_request = OneLogin::RubySaml::Authrequest.new
+    auth_url = auth_request.create(invalid_saml_settings)
+    CGI.unescape(auth_url.split("=").last)
+  end
+
   def make_saml_logout_request(requested_saml_logout_url = 'https://foo.example.com/saml/logout')
     request_builder = SamlIdp::LogoutRequestBuilder.new(
       'some_response_id',
@@ -42,6 +48,12 @@ module SamlRequestMacros
       digest_method: 'http://www.w3.org/2001/04/xmlenc#sha256',
       signature_method: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
     }
+    settings
+  end
+
+  def invalid_saml_settings(saml_acs_url = "https://foo.example.com/saml/consume")
+    settings = saml_settings.dup
+    settings.issuer = ''
     settings
   end
 


### PR DESCRIPTION
**Why**: `head` has been the recommended option since Rails 4.
`render nothing: true` has now been deprecated in Rails 5.1