### PR TITLE
Bump version to 0.5.0-18f

### DIFF
--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.4.3-18f'
+  VERSION = '0.5.0-18f'
 end


### PR DESCRIPTION
**Why**: We made some changes since the last tag that the IdP depends
on.