### PR TITLE
LG-2040: saml debugging 2

### DIFF
--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -76,7 +76,7 @@ module SamlIdp
           algorithm(options[:get_params][:SigAlg])
         else
           ref_elem = REXML::XPath.first(self, "//ds:Reference", {"ds"=>DSIG})
-          algorithm(REXML::XPath.first(ref_elem, "//ds:DigestMethod"))
+          algorithm(REXML::XPath.first(ref_elem, "//ds:DigestMethod", {"ds"=>DSIG}))
         end
       end
 
@@ -215,6 +215,7 @@ module SamlIdp
         if algorithm.is_a?(REXML::Element)
           algorithm = element.attribute("Algorithm").value
         end
+        log "~~~~~~ Algorithm: #{algorithm}"
         algorithm = algorithm && algorithm =~ /(rsa-)?sha(.*?)$/i && $2.to_i
         case algorithm
         when 256


### PR DESCRIPTION
A small update to properly namespace the search for the DigestMethod in the XML of the request.

If this proves to be the solution to the bug we're seeing, I'll clean up all the debug logging and write tests for this case.