### PR TITLE
LG-2206: include response id in signature

### DIFF
--- a/lib/saml_idp/logout_response_builder.rb
+++ b/lib/saml_idp/logout_response_builder.rb
@@ -29,6 +29,10 @@ module SamlIdp
       self.cloudhsm_key_label = cloudhsm_key_label
     end
 
+    def reference_id
+      response_id
+    end
+
     def build
       builder = Builder::XmlMarkup.new
       builder.LogoutResponse ID: response_id_string,

--- a/spec/lib/saml_idp/logout_response_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_response_builder_spec.rb
@@ -37,5 +37,12 @@ module SamlIdp
         expect(logout_response.validate).to eq true
       end
     end
+
+    it "includes the response_id in the signature" do
+      signed = subject.signed
+      doc = REXML::Document.new signed
+      signature = REXML::XPath.first(doc, "//ds:Signature", {"ds"=>SamlIdp::XMLSecurity::SignedDocument::DSIG})
+      expect(signature.to_s).to include(response_id)
+    end
   end
 end


### PR DESCRIPTION
The logout response was generating a new uuid for the signature reference id, rather than including the response_id.