### PR TITLE
NameIDPolicy format is no-longer required

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -132,14 +132,6 @@ module SamlIdp
       service_provider && service_provider.valid?
     end
 
-    def requested_name_id_format
-      if authn_request? && name_id_format_node
-        name_id_format_node.content
-      else
-        nil
-      end
-    end
-
     def service_provider
       return unless issuer.present?
       @_service_provider ||= ServiceProvider.new((service_provider_finder[issuer] || {}).merge(identifier: issuer))
@@ -154,17 +146,13 @@ module SamlIdp
       @_name_id ||= xpath("//saml:NameID", saml: assertion).first.try(:content)
     end
 
-    def name_id_format_node
-      @_name_id_format_node ||= xpath("//samlp:AuthnRequest/samlp:NameIDPolicy/@Format",
-        samlp: samlp,
-        saml: assertion).first
-    end
-    private :name_id_format_node
-
     def name_id_format
-      @_name_id_format ||= xpath("//samlp:NameIDPolicy", samlp: samlp).first.attributes['Format'].value
+      if authn_request? && name_id_format_node
+        name_id_format_node.content
+      else
+        nil
+      end
     end
-    private :name_id_format
 
     def session_index
       @_session_index ||= xpath("//samlp:SessionIndex", samlp: samlp).first.try(:content)
@@ -174,6 +162,13 @@ module SamlIdp
       @_document ||= Saml::XML::Document.parse(raw_xml)
     end
     private :document
+
+    def name_id_format_node
+      @_name_id_format_node ||= xpath("//samlp:AuthnRequest/samlp:NameIDPolicy/@Format",
+        samlp: samlp,
+        saml: assertion).first
+    end
+    private :name_id_format_node
 
     def authn_context_node
       @_authn_context_node ||= xpath("//samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef",

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -147,11 +147,8 @@ module SamlIdp
     end
 
     def name_id_format
-      if authn_request? && name_id_format_node
-        name_id_format_node.content
-      else
-        nil
-      end
+      return name_id_format_node.content if authn_request? && name_id_format_node
+      nil
     end
 
     def session_index
@@ -164,9 +161,9 @@ module SamlIdp
     private :document
 
     def name_id_format_node
-      @_name_id_format_node ||= xpath("//samlp:AuthnRequest/samlp:NameIDPolicy/@Format",
-        samlp: samlp,
-        saml: assertion).first
+      @_name_id_format_node ||= xpath('//samlp:AuthnRequest/samlp:NameIDPolicy/@Format',
+                                      samlp: samlp,
+                                      saml: assertion).first
     end
     private :name_id_format_node
 

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -161,6 +161,7 @@ module SamlIdp
     private :document
 
     def name_id_format_node
+      return @_name_id_format_node if defined?(@_name_id_format_node)
       @_name_id_format_node ||= xpath('//samlp:AuthnRequest/samlp:NameIDPolicy/@Format',
                                       samlp: samlp,
                                       saml: assertion).first

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -132,6 +132,14 @@ module SamlIdp
       service_provider && service_provider.valid?
     end
 
+    def requested_name_id_format
+      if authn_request? && name_id_format_node
+        name_id_format_node.content
+      else
+        nil
+      end
+    end
+
     def service_provider
       return unless issuer.present?
       @_service_provider ||= ServiceProvider.new((service_provider_finder[issuer] || {}).merge(identifier: issuer))
@@ -146,9 +154,17 @@ module SamlIdp
       @_name_id ||= xpath("//saml:NameID", saml: assertion).first.try(:content)
     end
 
+    def name_id_format_node
+      @_name_id_format_node ||= xpath("//samlp:AuthnRequest/samlp:NameIDPolicy/@Format",
+        samlp: samlp,
+        saml: assertion).first
+    end
+    private :name_id_format_node
+
     def name_id_format
       @_name_id_format ||= xpath("//samlp:NameIDPolicy", samlp: samlp).first.attributes['Format'].value
     end
+    private :name_id_format
 
     def session_index
       @_session_index ||= xpath("//samlp:SessionIndex", samlp: samlp).first.try(:content)

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 module SamlIdp
   describe Request do
-    let(:raw_authn_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
+    let(:raw_authn_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:persistent'/><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
 
     describe "deflated request" do
       let(:deflated_request) { Base64.encode64(Zlib::Deflate.deflate(raw_authn_request, 9)[2..-5]) }
@@ -55,6 +55,10 @@ module SamlIdp
 
       it "fetches internal request" do
         expect(subject.request['ID']).to eq(subject.request_id)
+      end
+
+      it "has a valid name id format" do
+        expect(subject.requested_name_id_format).to eq("urn:oasis:names:tc:SAML:1.1:nameid-format:persistent")
       end
 
       it "has a valid authn context" do

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -3,6 +3,8 @@ module SamlIdp
   describe Request do
     let(:raw_authn_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
 
+    let(:raw_authn_unspecidfied_name_id_format) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
+
     describe "deflated request" do
       let(:deflated_request) { Base64.encode64(Zlib::Deflate.deflate(raw_authn_request, 9)[2..-5]) }
 
@@ -71,6 +73,14 @@ module SamlIdp
         expect(authn_request.issuer).not_to eq('')
         expect(authn_request.issuer).to eq(nil)
         expect(authn_request.valid?).to eq(false)
+      end
+    end
+
+    describe "authn request with unspecidfied name id format" do
+      subject { described_class.new raw_authn_unspecidfied_name_id_format }
+
+      it "returns nil for name id format" do
+        expect(subject.name_id_format).to eq(nil)
       end
     end
 

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -3,7 +3,7 @@ module SamlIdp
   describe Request do
     let(:raw_authn_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
 
-    let(:raw_authn_unspecidfied_name_id_format) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
+    let(:raw_authn_unspecified_name_id_format) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
 
     describe "deflated request" do
       let(:deflated_request) { Base64.encode64(Zlib::Deflate.deflate(raw_authn_request, 9)[2..-5]) }
@@ -76,8 +76,8 @@ module SamlIdp
       end
     end
 
-    describe "authn request with unspecidfied name id format" do
-      subject { described_class.new raw_authn_unspecidfied_name_id_format }
+    describe "authn request with unspecified name id format" do
+      subject { described_class.new raw_authn_unspecified_name_id_format }
 
       it "returns nil for name id format" do
         expect(subject.name_id_format).to eq(nil)

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 module SamlIdp
   describe Request do
-    let(:raw_authn_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:persistent'/><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
+    let(:raw_authn_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
 
     describe "deflated request" do
       let(:deflated_request) { Base64.encode64(Zlib::Deflate.deflate(raw_authn_request, 9)[2..-5]) }
@@ -58,7 +58,7 @@ module SamlIdp
       end
 
       it "has a valid name id format" do
-        expect(subject.requested_name_id_format).to eq("urn:oasis:names:tc:SAML:1.1:nameid-format:persistent")
+        expect(subject.name_id_format).to eq("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress")
       end
 
       it "has a valid authn context" do


### PR DESCRIPTION
WHY:
As a partner trying to integrate with Login.gov using SAML, I do not want NameIDPolicy to be required in the AuthnRequest, so that I can use the default XML that Salseforce and other CRMs spit out without customization. 

https://cm-jira.usa.gov/browse/LG-3053