### PR TITLE
Lg 3053 specify name id format in authn response

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -44,6 +44,7 @@ module SamlIdp
       expiry = opts[:expiry] || 60*60
       encryption_opts = opts[:encryption] || nil
       signature_opts = opts[:signature] || {}
+      response_name_id_format = opts[:name_id_format] || saml_request.name_id_format
 
       response = SamlResponse.new(
         reference_id,
@@ -55,7 +56,7 @@ module SamlIdp
         saml_acs_url,
         (opts[:algorithm] || algorithm || default_algorithm),
         my_authn_context_classref,
-        saml_request.name_id_format,
+        response_name_id_format,
         signature_opts[:x509_certificate],
         signature_opts[:secret_key],
         signature_opts[:cloudhsm_key_label],

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -72,6 +72,8 @@ describe SamlIdp::Controller do
     it "should create a SAML Response" do
       saml_response = encode_response(principal)
       response = OneLogin::RubySaml::Response.new(saml_response)
+      name_id_format_email = Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS
+      expect(response.name_id_format).to eq(name_id_format_email)
       expect(response.name_id).to eq("foo@example.com")
       expect(response.issuers.first).to eq("http://example.com")
       response.settings = saml_settings
@@ -79,12 +81,12 @@ describe SamlIdp::Controller do
     end
 
     it "should create a SAML Response with specified name id format" do
-      my_name_id_format = Saml::XML::Namespaces::Formats::NameId::PERSISTENT
-      opts = {name_id_format: my_name_id_format}
+      name_id_format_persistent = Saml::XML::Namespaces::Formats::NameId::PERSISTENT
+      opts = {name_id_format: name_id_format_persistent}
       expect(principal).to receive(:id).twice
       saml_response = encode_response(principal, opts)
       response = OneLogin::RubySaml::Response.new(saml_response)
-      expect(response.name_id_format).to eq(my_name_id_format)
+      expect(response.name_id_format).to eq(name_id_format_persistent)
       expect(response.issuers.first).to eq("http://example.com")
     end
 

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -78,6 +78,16 @@ describe SamlIdp::Controller do
       expect(response.is_valid?).to be_truthy
     end
 
+    it "should create a SAML Response with specified name id format" do
+      my_name_id_format = Saml::XML::Namespaces::Formats::NameId::PERSISTENT
+      opts = {name_id_format: my_name_id_format}
+      expect(principal).to receive(:id).twice
+      saml_response = encode_response(principal, opts)
+      response = OneLogin::RubySaml::Response.new(saml_response)
+      expect(response.name_id_format).to eq(my_name_id_format)
+      expect(response.issuers.first).to eq("http://example.com")
+    end
+
     it "should sign a SAML Response if requested" do
       saml_response_encoded = encode_response(principal, signed_response_message: true)
       saml_response_text = Base64.decode64(saml_response_encoded)


### PR DESCRIPTION
WHY:
This is a follow up PR to:
https://github.com/18F/saml_idp/pull/31

There is a draft PR:
https://github.com/18F/identity-idp/pull/3912/files
in the IDP once this is merged that will default to:
urn:oasis:names:tc:SAML:1.1:nameid-format:persistent

Slack discussion here:
https://gsa-tts.slack.com/archives/C0NGESUN5/p1594655231247100

For this story:
https://cm-jira.usa.gov/browse/LG-3053
As a partner trying to integrate with Login.gov using SAML, I do not want NameIDPolicy to be required in the AuthnRequest, so that I can use the default XML that Salseforce and other CRMs spit out without customization.




