### PR TITLE
Ensure NameID formats actually match the spec

### DIFF
--- a/lib/saml_idp/name_id_formatter.rb
+++ b/lib/saml_idp/name_id_formatter.rb
@@ -13,14 +13,18 @@ module SamlIdp
         one_one.map { |key_val| build("1.1", key_val)[:name] } +
         two_zero.map { |key_val| build("2.0", key_val)[:name] }
       else
-        list.map { |key_val| build("2.0", key_val)[:name] }
+        list.map do |key_val|
+          format_symbol = Array(key_val).first
+          version = one_one_nameid_format?(format_symbol) ? '1.1' : '2.0'
+          build(version, key_val)[:name]
+        end
       end
     end
 
     def chosen
       return default_name_getter_hash unless list.key?(symbolized_name_id_format)
 
-      version = one_one_nameid_format? ? '1.1' : '2.0'
+      version = one_one_nameid_format?(symbolized_name_id_format) ? '1.1' : '2.0'
       requested = list.find { |k, _| k == symbolized_name_id_format }
 
       build(version, requested)
@@ -37,7 +41,7 @@ module SamlIdp
       @symbolized_name_id_format ||= sp_name_id_format.split(':').last.underscore.to_sym
     end
 
-    def one_one_nameid_format?
+    def one_one_nameid_format?(format)
       one_one_nameid_formats = %i[
         email_address
         unspecified
@@ -45,7 +49,7 @@ module SamlIdp
         x509_subject_name
       ]
 
-      one_one_nameid_formats.include?(symbolized_name_id_format)
+      one_one_nameid_formats.include?(format)
     end
 
     def build(version, key_val)

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.11.0-18f'.freeze
+  VERSION = '0.12.0-18f'.freeze
 end

--- a/spec/lib/saml_idp/name_id_formatter_spec.rb
+++ b/spec/lib/saml_idp/name_id_formatter_spec.rb
@@ -7,7 +7,27 @@ module SamlIdp
       let(:list) { { email_address: ->() { "foo@example.com" } } }
 
       it "has a valid all" do
-        expect(subject.all).to eq(["urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"])
+        expect(subject.all).to eq(["urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"])
+      end
+    end
+
+    describe "with options that require different version numbers" do
+      let(:list) do
+        %i[unspecified email_address x509_subject_name windows_domain_qualified_name
+           kerberos entity persistent transient]
+      end
+
+      it "has a valid all" do
+        expect(subject.all).to match_array([
+          "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+          "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+          "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
+          "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
+          "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
+          "urn:oasis:names:tc:SAML:2.0:nameid-format:entity",
+          "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+          "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+        ])
       end
     end
 
@@ -32,7 +52,7 @@ module SamlIdp
 
       it "has a valid all" do
         expect(subject.all).to eq([
-          "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress",
+          "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
           "urn:oasis:names:tc:SAML:2.0:nameid-format:undefined",
         ])
       end


### PR DESCRIPTION
Resolves LG-4273

Section 8.3 of the SAML 2.0 spec specifies that the email address NameID
format should be versioned at 1.1, but earlier work has modified this
library such that the metadata generator specifies it at 2.0. This makes
things consistent with the spec by checking an individual format for the
appropriate version number before generating it.