### PR TITLE
LG-4428: saml stop logging request body

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -22,7 +22,6 @@ module SamlIdp
       Rails.logger.info "validate_saml_request"
 
       decode_request(raw_saml_request)
-      Rails.logger.info "#{"*" * 80}\nSAML Request:\n#{self.saml_request.inspect}\nDone with SAML Request\n#{"*" * 80}"
 
       head :forbidden unless valid_saml_request?
     end

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -19,7 +19,7 @@ module SamlIdp
     protected
 
     def validate_saml_request(raw_saml_request = params[:SAMLRequest])
-      Rails.logger.info "validate_saml_request"
+      log "validate_saml_request"
 
       decode_request(raw_saml_request)
 
@@ -127,6 +127,14 @@ module SamlIdp
 
     def default_algorithm
       OpenSSL::Digest::SHA256
+    end
+
+    def log(msg, level: :debug)
+      if Rails && Rails.logger
+        Rails.logger.send(level, msg)
+      else
+        puts msg
+      end
     end
   end
 end

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -26,9 +26,9 @@ module SamlIdp
       new(inflated, options)
     end
 
-    def self.log(msg)
+    def self.log(msg, level: :debug)
       if Rails && Rails.logger
-        Rails.logger.info msg
+        Rails.logger.send(level, msg)
       else
         puts msg
       end

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.12.0-18f'.freeze
+  VERSION = '0.12.1-18f'.freeze
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -44,7 +44,7 @@ module SamlIdp
       end
 
       def validate(idp_cert_fingerprint, soft = true, options = {})
-        Rails.logger.info 'Validate the fingerprint'
+        log 'Validate the fingerprint'
         base64_cert = find_base64_cert(options)
         cert_text   = Base64.decode64(base64_cert)
         cert        = OpenSSL::X509::Certificate.new(cert_text)
@@ -127,7 +127,7 @@ module SamlIdp
           relay_state: params[:RelayState],
           sig_alg: params[:SigAlg]
         )
-log '***** validate_doc_params_signature: verify_signature:'
+        log '***** validate_doc_params_signature: verify_signature:'
         verify_signature(base64_cert, params[:SigAlg], Base64.decode64(params[:Signature]), canon_string, soft)
       end
 
@@ -178,7 +178,7 @@ log '***** validate_doc_params_signature: verify_signature:'
         signature               = Base64.decode64(base64_signature)
         sig_alg                 = REXML::XPath.first(signed_info_element, "//ds:SignatureMethod", sig_namespace_hash)
 
-log '***** validate_doc_embedded_signature: verify_signature:'
+        log '***** validate_doc_embedded_signature: verify_signature:'
         verify_signature(base64_cert, sig_alg, signature, canon_string, soft)
       end
 
@@ -245,9 +245,9 @@ log '***** validate_doc_embedded_signature: verify_signature:'
         end
       end
 
-      def log(msg)
+      def log(msg, level: :debug)
         if Rails && Rails.logger
-          Rails.logger.info msg
+          Rails.logger.send(level, msg)
         else
           puts msg
         end


### PR DESCRIPTION
This logging was added prior to knowledge of the [SAML debugging tools available](https://handbook.login.gov/articles/saml.html#tools) and is no longer necessary.

Similar to https://github.com/18F/identity-idp/pull/4873