### PR TITLE
add default aal authn context

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -4,7 +4,7 @@ module SamlIdp
   class Request
     IAL_PREFIX = %r{^http://idmanagement.gov/ns/assurance/ial}.freeze
     LOA_PREFIX = %r{^http://idmanagement.gov/ns/assurance/loa}.freeze
-    AAL_PREFIX = %r{^http://idmanagement.gov/ns/assurance/aal}.freeze
+    AAL_PREFIX = %r{^http://idmanagement.gov/ns/assurance/aal|urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo}.freeze
 
     def self.from_deflated_request(raw, options = {})
       if raw

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.12.1-18f'.freeze
+  VERSION = '0.12.2-18f'.freeze
 end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 module SamlIdp
   describe Request do
     let(:aal) { 'http://idmanagement.gov/ns/assurance/aal/3' }
+    let(:default_aal) { 'urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo' }
     let(:ial) { 'http://idmanagement.gov/ns/assurance/ial/2' }
     let(:password) { 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password' }
     let(:authn_context_classref) { build_authn_context_classref(password) }
@@ -130,6 +131,14 @@ module SamlIdp
 
         it "should return nil" do
           expect(subject.requested_aal_authn_context).to be_nil
+        end
+      end
+
+      context "context requested is default aal" do
+        let(:authn_context_classref) { build_authn_context_classref(default_aal) }
+
+        it "should return the aal uri" do
+          expect(subject.requested_aal_authn_context).to eq(default_aal)
         end
       end
 


### PR DESCRIPTION
WHY:
If a service provider passes the default aal value (urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo) in the authn contexts it will not be recognized or returned in requested_aal_authn_context.