### PR TITLE
LG-4181 - Protect against rogue SAML requests

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -24,6 +24,11 @@ module SamlIdp
       decode_request(raw_saml_request)
 
       head :forbidden unless valid_saml_request?
+
+    rescue Nokogiri::XML::SyntaxError => e
+      log "Nokogiri::XML::SyntaxError validating request"
+      log e
+      head :bad_request
     end
 
     def decode_request(raw_saml_request)

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.13.0-18f'.freeze
+  VERSION = '0.14.0-18f'.freeze
 end

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -146,4 +146,19 @@ describe SamlIdp::Controller do
       validate_saml_request
     end
   end
+
+  context 'invalid XML in SAML Request' do
+    # This was encountered IRL on 2021-02-09
+    before do
+      allow_any_instance_of(subject).to receive(:valid_saml_request?).and_raise(Nokogiri::XML::SyntaxError)
+    end
+
+    it 'returns headers only with a bad_request status' do
+      params[:SAMLRequest] = make_saml_request
+
+      expect(self).to receive(:head).with(:bad_request)
+
+      validate_saml_request
+    end
+  end
 end


### PR DESCRIPTION
This is in response to some 500 errors we had due to bogus SAML requests.