### PR TITLE
Always set @matching_cert, not just when signature is required

### DIFF
--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -21,13 +21,14 @@ module SamlIdp
     end
 
     def valid_signature?(doc, require_signature = false, options = {})
-      if require_signature || should_validate_signature?
-        Array(certs).any? do |cert|
-          if doc.valid_signature?(fingerprint_cert(cert), options.merge(cert: cert))
-            @matching_cert = cert
-            true
-          end
+      Array(certs).any? do |cert|
+        if doc.valid_signature?(fingerprint_cert(cert), options.merge(cert: cert))
+          @matching_cert = cert
         end
+      end
+
+      if require_signature || should_validate_signature?
+        !!@matching_cert
       else
         true
       end

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.14.2-18f'.freeze
+  VERSION = '0.14.3-18f'.freeze
 end


### PR DESCRIPTION
So, this sneaky side effect is still not a great way to set this value... but given that it needs the `doc` on hand, I still think this is an okay place for this check


In order to test this:
1. I loaded up the [identity-saml-sinatra](https://github.com/18F/identity-saml-sinatra) locally
2. I generated a new public/private key pair from our [developer docs](https://developers.login.gov/testing/#creating-a-public-certificate), and after converting the private key to the right format
3. in the IDP locally set both old and new public keys for the DB
4. checked that signing in worked, even after flip-flopping the order of the certs in the DB (because the [`certs.first`](https://github.com/18F/identity-idp/blob/0b2176ecfe249e70e92b8175b0433a4d3dfa5569/app/controllers/concerns/saml_idp_auth_concern.rb#L161-L162) in the IDP was likely masking some failures)
