### PR TITLE
LG-5120: update circleci ruby image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            sudo apt install sqlite3
             gem install bundler
             bundle install --jobs=4 --retry=3 --path vendor/bundle
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: cimg/ruby:2.7.3
+      - image: cimg/ruby:2.7-browsers
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: a989576c2cf27161879ca9dfc4044dcd07ffc9d4b03827f6d464fcfff6c896a0
@@ -21,7 +21,6 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            sudo apt install sqlite3
             gem install bundler
             bundle install --jobs=4 --retry=3 --path vendor/bundle
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,12 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: circleci/ruby:2.6
+      - image: cimg/ruby:2.7.3
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: a989576c2cf27161879ca9dfc4044dcd07ffc9d4b03827f6d464fcfff6c896a0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: cimg/ruby:2.7-browsers
+      - image: cimg/ruby:2.7
         environment:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: a989576c2cf27161879ca9dfc4044dcd07ffc9d4b03827f6d464fcfff6c896a0
@@ -17,6 +17,10 @@ jobs:
 
     steps:
       - checkout
+
+      - run:
+          name: Install sqlite3
+          command: sudo apt update && sudo apt-get install -y libsqlite3-dev
 
       - run:
           name: Install dependencies


### PR DESCRIPTION
An email from CircleCI:

> As of Dec 31, 2021, legacy images will no longer be supported on CircleCI