### PR TITLE
Add SingleLogoutService back to metadata builder

### DIFF
--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -14,6 +14,7 @@ module SamlIdp
     attr_accessor :attribute_service_location
     attr_accessor :single_service_post_location
     attr_accessor :single_logout_service_post_location
+    attr_accessor :remote_logout_service_post_location
     attr_accessor :attributes
     attr_accessor :service_provider
     attr_accessor :pkcs11

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -37,6 +37,14 @@ module SamlIdp
                 Location: single_service_post_location
               descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
                 Location: single_service_post_location
+              descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                Location: single_logout_service_post_location
+              descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                Location: single_logout_service_post_location
+              if remote_logout_service_post_location.present?
+                descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                  Location: remote_logout_service_post_location
+              end
               build_attribute descriptor
             end
 
@@ -149,6 +157,7 @@ module SamlIdp
       attribute_service_location
       single_service_post_location
       single_logout_service_post_location
+      remote_logout_service_post_location
       technical_contact
     ].each do |delegatable|
       define_method(delegatable) do

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.16.0-18f'.freeze
+  VERSION = '0.17.0-18f'.freeze
 end

--- a/spec/lib/saml_idp/configurator_spec.rb
+++ b/spec/lib/saml_idp/configurator_spec.rb
@@ -11,6 +11,7 @@ module SamlIdp
     it { is_expected.to respond_to :attribute_service_location }
     it { is_expected.to respond_to :single_service_post_location }
     it { is_expected.to respond_to :single_logout_service_post_location }
+    it { is_expected.to respond_to :remote_logout_service_post_location }
     it { is_expected.to respond_to :name_id }
     it { is_expected.to respond_to :attributes }
     it { is_expected.to respond_to :service_provider }


### PR DESCRIPTION
Release v0.17.0-18f

**Why:** Certain SAML clients use the SingleLogoutService elements in
the metadata to configure their logout behavior. This was originally
removed in https://github.com/18F/saml_idp/pull/30 but it is unclear why.