### PR TITLE
configure if IDP want requests to be signed

### DIFF
--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -8,6 +8,7 @@ module SamlIdp
     attr_accessor :algorithm
     attr_accessor :organization_name
     attr_accessor :organization_url
+    attr_accessor :want_authn_requests_signed
     attr_accessor :base_saml_location
     attr_accessor :entity_id
     attr_accessor :reference_id_generator

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -30,7 +30,7 @@ module SamlIdp
           entityID: entity_id do |entity|
             sign entity
 
-            entity.IDPSSODescriptor protocolSupportEnumeration: protocol_enumeration do |descriptor|
+            entity.IDPSSODescriptor protocolSupportEnumeration: protocol_enumeration, WantAuthnRequestsSigned: want_authn_requests_signed.present? do |descriptor|
               build_key_descriptor descriptor
               build_name_id_formats descriptor
               descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
@@ -154,6 +154,7 @@ module SamlIdp
       support_email
       organization_name
       organization_url
+      want_authn_requests_signed
       attribute_service_location
       single_service_post_location
       single_logout_service_post_location

--- a/spec/lib/saml_idp/metadata_builder_spec.rb
+++ b/spec/lib/saml_idp/metadata_builder_spec.rb
@@ -46,6 +46,15 @@ module SamlIdp
       expect(subject.fresh.scan(/SingleLogoutService/).count).to eq(2)
     end
 
+    it "does not want requests signed by default" do
+      expect(subject.fresh.scan(/WantAuthnRequestsSigned="false"/).count).to eq(1)
+    end
+
+    it "wants requests signed when told to " do
+      subject.configurator.want_authn_requests_signed = true
+      expect(subject.fresh.scan(/WantAuthnRequestsSigned="true"/).count).to eq(1)
+    end
+
     def slo_regex(binding, location)
       %r{<SingleLogoutService Binding=.+#{binding}.+ Location=.+#{location}.+/>}
     end


### PR DESCRIPTION
This will add a new configuration option that allows to control if the metadata instruct the consuming SP to send requests signed or not.