### PR TITLE
drop UUID gem in favor of SecureRandom

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ CERT
   # config.organization_name = "Your Organization"
   # config.organization_url = "http://example.com"
   # config.base_saml_location = "#{base}/saml"
-  # config.reference_id_generator                   # Default: -> { UUID.generate }
+  # config.reference_id_generator                   # Default: -> { SecureRandom.uuid }
   # config.attribute_service_location = "#{base}/saml/attributes"
   # config.single_service_post_location = "#{base}/saml/auth"
 

--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -25,7 +25,7 @@ module SamlIdp
       self.x509_certificate = Default::X509_CERTIFICATE
       self.secret_key = Default::SECRET_KEY
       self.algorithm = :sha1
-      self.reference_id_generator = ->() { UUID.generate }
+      self.reference_id_generator = ->() { SecureRandom.uuid }
       self.service_provider = OpenStruct.new
       self.service_provider.finder = ->(_) { Default::SERVICE_PROVIDER }
       self.service_provider.metadata_persister = ->(id, settings) {  }

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -2,7 +2,7 @@
 require 'openssl'
 require 'base64'
 require 'time'
-require 'uuid'
+require 'securerandom'
 require 'saml_idp/request'
 require 'saml_idp/logout_response_builder'
 module SamlIdp
@@ -123,11 +123,11 @@ module SamlIdp
     end
 
     def get_saml_response_id
-      UUID.generate
+      SecureRandom.uuid
     end
 
     def get_saml_reference_id
-      UUID.generate
+      SecureRandom.uuid
     end
 
     def default_algorithm

--- a/lib/saml_idp/logout_builder.rb
+++ b/lib/saml_idp/logout_builder.rb
@@ -9,7 +9,7 @@ module SamlIdp
     end
 
     def reference_id
-      UUID.generate
+      SecureRandom.uuid
     end
 
     def digest

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -42,7 +42,6 @@ section of the README.
   INST
 
   s.add_dependency('activesupport')
-  s.add_dependency('uuid')
   s.add_dependency('builder')
   s.add_dependency('faraday')
   s.add_dependency('nokogiri', '>= 1.10.2')


### PR DESCRIPTION
So that we can drop the `uuid` gem from the IDP

It looks like upstream made a similar change a while back