### PR TITLE
Fix invalid signature algorithm exception

### DIFF
--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.18.0-18f'.freeze
+  VERSION = '0.18.1-18f'.freeze
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -89,7 +89,7 @@ module SamlIdp
       def fingerprint_cert(cert, options)
         digest_algorithm = signature_algorithm(options)
         return nil unless digest_algorithm
-        digest_algorithm.hexdigest(cert.to_der)
+        digest_algorithm&.hexdigest(cert.to_der)
       end
 
       def fingerprint_cert_sha1(cert)

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -81,12 +81,14 @@ module SamlIdp
           algorithm(options[:get_params][:SigAlg])
         else
           ref_elem = REXML::XPath.first(self, "//ds:Reference", {"ds"=>DSIG})
+          return nil unless ref_elem
           algorithm(REXML::XPath.first(ref_elem, "//ds:DigestMethod", {"ds"=>DSIG}))
         end
       end
 
       def fingerprint_cert(cert, options)
         digest_algorithm = signature_algorithm(options)
+        return nil unless digest_algorithm
         digest_algorithm.hexdigest(cert.to_der)
       end
 


### PR DESCRIPTION
We received a few exceptions from an invalid request that raises an exception when trying to search a path on an element that doesn't exist ([NewRelic](https://onenr.io/0kjnA48YXRo))