### PR TITLE
Add `SamlIdp::Request#requested_vtr_authn_context`

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -5,6 +5,7 @@ module SamlIdp
     IAL_PREFIX = %r{^http://idmanagement.gov/ns/assurance/ial}.freeze
     LOA_PREFIX = %r{^http://idmanagement.gov/ns/assurance/loa}.freeze
     AAL_PREFIX = %r{^http://idmanagement.gov/ns/assurance/aal|urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo}.freeze
+    VTR_REGEXP = %r{[A-Z][a-z0-9](\.[A-Z][a-z0-9])*}.freeze
 
     def self.from_deflated_request(raw, options = {})
       if raw
@@ -99,6 +100,12 @@ module SamlIdp
     def requested_aal_authn_context
       requested_authn_contexts.select do |classref|
         AAL_PREFIX.match?(classref)
+      end.first
+    end
+
+    def requested_vtr_authn_context
+      requested_authn_contexts.select do |classref|
+        VTR_REGEXP.match?(classref)
       end.first
     end
 

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.18.3-18f'.freeze
+  VERSION = '0.19.0-18f'.freeze
 end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -4,6 +4,7 @@ module SamlIdp
     let(:aal) { 'http://idmanagement.gov/ns/assurance/aal/3' }
     let(:default_aal) { 'urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo' }
     let(:ial) { 'http://idmanagement.gov/ns/assurance/ial/2' }
+    let(:vtr) { 'C1.C2.P1.Pb' }
     let(:password) { 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password' }
     let(:authn_context_classref) { build_authn_context_classref(password) }
     let(:issuer) { 'localhost:3000' }
@@ -233,6 +234,34 @@ module SamlIdp
 
         it 'should return the ial uri' do
           expect(subject.requested_ial_authn_context).to eq(ial)
+        end
+      end
+    end
+
+    describe '#requested_vtr_authn_context' do
+      subject { described_class.new raw_authn_request }
+
+      context 'no vtr context requested' do
+        let(:authn_context_classref) { '' }
+
+        it 'should return nil' do
+          expect(subject.requested_vtr_authn_context).to be_nil
+        end
+      end
+
+      context 'only vtr is requested' do
+        let(:authn_context_classref) { build_authn_context_classref(vtr) }
+
+        it 'should return the vrt' do
+          expect(subject.requested_vtr_authn_context).to eq(vtr)
+        end
+      end
+
+      context 'multiple contexts including vtr' do
+        let(:authn_context_classref) { build_authn_context_classref([vtr, ial]) }
+
+        it 'should return the vrt' do
+          expect(subject.requested_vtr_authn_context).to eq(vtr)
         end
       end
     end


### PR DESCRIPTION
We are working on adding support to making requests with vectors of trust. In order to do so we need to recognize when SAML requests are made with a vector of trust.

This commit adds a `SamlIdp::Request#requested_vtr_authn_context` method. It is a similar implementation to `#requested_ial_authn_context` and `#requested_aal_authn_context`. This implementation differs by recognizing AuthnContexts that include a VTR and returns the contents of the first AuthnContext that includes a VTR.