### PR TITLE
Add stricter VTR validation

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -5,7 +5,7 @@ module SamlIdp
     IAL_PREFIX = %r{^http://idmanagement.gov/ns/assurance/ial}.freeze
     LOA_PREFIX = %r{^http://idmanagement.gov/ns/assurance/loa}.freeze
     AAL_PREFIX = %r{^http://idmanagement.gov/ns/assurance/aal|urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo}.freeze
-    VTR_REGEXP = %r{[A-Z][a-z0-9](\.[A-Z][a-z0-9])*}.freeze
+    VTR_REGEXP = %r{\A[A-Z][a-z0-9](\.[A-Z][a-z0-9])*\z}.freeze
 
     def self.from_deflated_request(raw, options = {})
       if raw

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.19.0-18f'.freeze
+  VERSION = '0.19.1-18f'.freeze
 end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -264,6 +264,26 @@ module SamlIdp
           expect(subject.requested_vtr_authn_context).to eq(vtr)
         end
       end
+
+      context 'context that contains a VTR substring but is not a VTR' do
+        let(:authn_context_classref) do
+          fake_vtr = 'Not a VTR but does contain LetT3.Rs and Nu.Mb.Ers'
+          build_authn_context_classref(fake_vtr)
+        end
+
+        it 'does not match on the context' do
+          expect(subject.requested_vtr_authn_context).to be_nil
+        end
+      end
+
+      context 'with the default MFA context' do
+        let(:aal) { 'urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo' }
+        let(:authn_context_classref) { build_authn_context_classref(aal) }
+
+        it 'does not match on the context' do
+          expect(subject.requested_vtr_authn_context).to be_nil
+        end
+      end
     end
 
     describe '#valid?' do


### PR DESCRIPTION
A previous commit added a regex that looked like this to detect a VTR:

```
[A-Z][a-z0-9](\.[A-Z][a-z0-9])*
```

That turned out to be a regex that _also_ matches on this valid authn context:

```
urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo
```

This commit modifies the regex so it must match on the entire string to be valid to fix this issue.