### PR TITLE
Reorder metadata to validate against xsd

### DIFF
--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -32,11 +32,6 @@ module SamlIdp
 
             entity.IDPSSODescriptor protocolSupportEnumeration: protocol_enumeration do |descriptor|
               build_key_descriptor descriptor
-              build_name_id_formats descriptor
-              descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                Location: single_service_post_location
-              descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                Location: single_service_post_location
               descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
                 Location: single_logout_service_post_location
               descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
@@ -45,6 +40,11 @@ module SamlIdp
                 descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
                   Location: remote_logout_service_post_location
               end
+              build_name_id_formats descriptor
+              descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                Location: single_service_post_location
+              descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                Location: single_service_post_location
               build_attribute descriptor
             end
 

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.19.1-18f'.freeze
+  VERSION = '0.19.2-18f'.freeze
 end

--- a/spec/lib/saml_idp/metadata_builder_spec.rb
+++ b/spec/lib/saml_idp/metadata_builder_spec.rb
@@ -3,51 +3,62 @@ module SamlIdp
   describe MetadataBuilder do
     include CloudhsmMockable
 
-    it "has a valid fresh" do
-      expect(subject.fresh).not_to be_empty
+    describe '#signed' do
+      it "signs valid xml" do
+        expect(Saml::XML::Document.parse(subject.signed).valid_signature?(Default::FINGERPRINT)).to be_truthy
+      end
+
+      it "signs valid xml with a custom cert and private key" do
+        subject = MetadataBuilder.new(
+          SamlIdp.config,
+          custom_idp_x509_cert,
+          custom_idp_secret_key
+        )
+        expect(Saml::XML::Document.parse(subject.signed).valid_signature?(custom_idp_x509_cert_fingerprint)).to be_truthy
+      end
+
+      it "signs valid xml with a cloudhsm key" do
+        mock_cloudhsm
+        subject = MetadataBuilder.new(
+          SamlIdp.config,
+          cloudhsm_idp_x509_cert,
+          nil,
+          'secret'
+        )
+        expect(Saml::XML::Document.parse(subject.signed).valid_signature?(cloudhsm_idp_x509_cert_fingerprint)).to be_truthy
+      end
     end
 
-    it "signs valid xml" do
-      expect(Saml::XML::Document.parse(subject.signed).valid_signature?(Default::FINGERPRINT)).to be_truthy
-    end
+    describe '#fresh' do
+      let(:schema) { Nokogiri::XML::Schema(File.open('spec/support/schema/saml-schema-metadata-2.0.xsd')) }
+      let(:doc) { Nokogiri::XML(subject.fresh) }
 
-    it "signs valid xml with a custom cert and private key" do
-      subject = MetadataBuilder.new(
-        SamlIdp.config,
-        custom_idp_x509_cert,
-        custom_idp_secret_key
-      )
-      expect(Saml::XML::Document.parse(subject.signed).valid_signature?(custom_idp_x509_cert_fingerprint)).to be_truthy
-    end
+      it "is not empty" do
+        expect(subject.fresh).not_to be_empty
+      end
 
-    it "signs valid xml with a cloudhsm key" do
-      mock_cloudhsm
-      subject = MetadataBuilder.new(
-        SamlIdp.config,
-        cloudhsm_idp_x509_cert,
-        nil,
-        'secret'
-      )
-      expect(Saml::XML::Document.parse(subject.signed).valid_signature?(cloudhsm_idp_x509_cert_fingerprint)).to be_truthy
-    end
+      it "includes logout elements" do
+        subject.configurator.single_logout_service_post_location = 'https://example.com/saml/logout'
+        subject.configurator.remote_logout_service_post_location = 'https://example.com/saml/remote_logout'
+        expect(subject.fresh.scan(/SingleLogoutService/).count).to eq(3)
+        expect(subject.fresh).to match(slo_regex('HTTP-POST', 'https://example.com/saml/logout'))
+        expect(subject.fresh).to match(slo_regex('HTTP-Redirect', 'https://example.com/saml/logout'))
+        expect(subject.fresh).to match(slo_regex('HTTP-POST', 'https://example.com/saml/remote_logout'))
+      end
 
-    it "includes logout elements" do
-      subject.configurator.single_logout_service_post_location = 'https://example.com/saml/logout'
-      subject.configurator.remote_logout_service_post_location = 'https://example.com/saml/remote_logout'
-      expect(subject.fresh.scan(/SingleLogoutService/).count).to eq(3)
-      expect(subject.fresh).to match(slo_regex('HTTP-POST', 'https://example.com/saml/logout'))
-      expect(subject.fresh).to match(slo_regex('HTTP-Redirect', 'https://example.com/saml/logout'))
-      expect(subject.fresh).to match(slo_regex('HTTP-POST', 'https://example.com/saml/remote_logout'))
-    end
+      it "skips remote logout if not present" do
+        subject.configurator.single_logout_service_post_location = 'https://example.com/saml/logout'
+        subject.configurator.remote_logout_service_post_location = nil
+        expect(subject.fresh.scan(/SingleLogoutService/).count).to eq(2)
+      end
 
-    it "skips remote logout if not present" do
-      subject.configurator.single_logout_service_post_location = 'https://example.com/saml/logout'
-      subject.configurator.remote_logout_service_post_location = nil
-      expect(subject.fresh.scan(/SingleLogoutService/).count).to eq(2)
-    end
+      it 'validates against the xsd schema' do
+        expect(schema.valid?(doc)).to be true
+      end
 
-    def slo_regex(binding, location)
-      %r{<SingleLogoutService Binding=.+#{binding}.+ Location=.+#{location}.+/>}
+      def slo_regex(binding, location)
+        %r{<SingleLogoutService Binding=.+#{binding}.+ Location=.+#{location}.+/>}
+      end
     end
   end
 end

--- a/spec/support/schema/saml-schema-assertion-2.0.xsd
+++ b/spec/support/schema/saml-schema-assertion-2.0.xsd
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<schema
+    targetNamespace="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns="http://www.w3.org/2001/XMLSchema"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"
+    elementFormDefault="unqualified"
+    attributeFormDefault="unqualified"
+    blockDefault="substitution"
+    version="2.0">
+    <import namespace="http://www.w3.org/2000/09/xmldsig#"
+        schemaLocation="xmldsig-core-schema.xsd"/>
+    <import namespace="http://www.w3.org/2001/04/xmlenc#"
+        schemaLocation="xenc-schema.xsd"/>
+    <annotation>
+        <documentation>
+            Document identifier: saml-schema-assertion-2.0
+            Location: http://docs.oasis-open.org/security/saml/v2.0/
+            Revision history:
+            V1.0 (November, 2002):
+              Initial Standard Schema.
+            V1.1 (September, 2003):
+              Updates within the same V1.0 namespace.
+            V2.0 (March, 2005):
+              New assertion schema for SAML V2.0 namespace.
+        </documentation>
+    </annotation>
+    <attributeGroup name="IDNameQualifiers">
+        <attribute name="NameQualifier" type="string" use="optional"/>
+        <attribute name="SPNameQualifier" type="string" use="optional"/>
+    </attributeGroup>
+    <element name="BaseID" type="saml:BaseIDAbstractType"/>
+    <complexType name="BaseIDAbstractType" abstract="true">
+        <attributeGroup ref="saml:IDNameQualifiers"/>
+    </complexType>
+    <element name="NameID" type="saml:NameIDType"/>
+    <complexType name="NameIDType">
+        <simpleContent>
+            <extension base="string">
+                <attributeGroup ref="saml:IDNameQualifiers"/>
+                <attribute name="Format" type="anyURI" use="optional"/>
+                <attribute name="SPProvidedID" type="string" use="optional"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <complexType name="EncryptedElementType">
+        <sequence>
+            <element ref="xenc:EncryptedData"/>
+            <element ref="xenc:EncryptedKey" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+    </complexType>
+    <element name="EncryptedID" type="saml:EncryptedElementType"/>
+    <element name="Issuer" type="saml:NameIDType"/>
+    <element name="AssertionIDRef" type="NCName"/>
+    <element name="AssertionURIRef" type="anyURI"/>
+    <element name="Assertion" type="saml:AssertionType"/>
+    <complexType name="AssertionType">
+        <sequence>
+            <element ref="saml:Issuer"/>
+            <element ref="ds:Signature" minOccurs="0"/>
+            <element ref="saml:Subject" minOccurs="0"/>
+            <element ref="saml:Conditions" minOccurs="0"/>
+            <element ref="saml:Advice" minOccurs="0"/>
+            <choice minOccurs="0" maxOccurs="unbounded">
+                <element ref="saml:Statement"/>
+                <element ref="saml:AuthnStatement"/>
+                <element ref="saml:AuthzDecisionStatement"/>
+                <element ref="saml:AttributeStatement"/>
+            </choice>
+        </sequence>
+        <attribute name="Version" type="string" use="required"/>
+        <attribute name="ID" type="ID" use="required"/>
+        <attribute name="IssueInstant" type="dateTime" use="required"/>
+    </complexType>
+    <element name="Subject" type="saml:SubjectType"/>
+    <complexType name="SubjectType">
+        <choice>
+            <sequence>
+                <choice>
+                    <element ref="saml:BaseID"/>
+                    <element ref="saml:NameID"/>
+                    <element ref="saml:EncryptedID"/>
+                </choice>
+                <element ref="saml:SubjectConfirmation" minOccurs="0" maxOccurs="unbounded"/>
+            </sequence>
+            <element ref="saml:SubjectConfirmation" maxOccurs="unbounded"/>
+        </choice>
+    </complexType>
+    <element name="SubjectConfirmation" type="saml:SubjectConfirmationType"/>
+    <complexType name="SubjectConfirmationType">
+        <sequence>
+            <choice minOccurs="0">
+                <element ref="saml:BaseID"/>
+                <element ref="saml:NameID"/>
+                <element ref="saml:EncryptedID"/>
+            </choice>
+            <element ref="saml:SubjectConfirmationData" minOccurs="0"/>
+        </sequence>
+        <attribute name="Method" type="anyURI" use="required"/>
+    </complexType>
+    <element name="SubjectConfirmationData" type="saml:SubjectConfirmationDataType"/>
+    <complexType name="SubjectConfirmationDataType" mixed="true">
+        <complexContent>
+            <restriction base="anyType">
+                <sequence>
+                    <any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+                <attribute name="NotBefore" type="dateTime" use="optional"/>
+                <attribute name="NotOnOrAfter" type="dateTime" use="optional"/>
+                <attribute name="Recipient" type="anyURI" use="optional"/>
+                <attribute name="InResponseTo" type="NCName" use="optional"/>
+                <attribute name="Address" type="string" use="optional"/>
+                <anyAttribute namespace="##other" processContents="lax"/>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <complexType name="KeyInfoConfirmationDataType" mixed="false">
+        <complexContent>
+            <restriction base="saml:SubjectConfirmationDataType">
+                <sequence>
+                    <element ref="ds:KeyInfo" maxOccurs="unbounded"/>
+                </sequence>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <element name="Conditions" type="saml:ConditionsType"/>
+    <complexType name="ConditionsType">
+        <choice minOccurs="0" maxOccurs="unbounded">
+            <element ref="saml:Condition"/>
+            <element ref="saml:AudienceRestriction"/>
+            <element ref="saml:OneTimeUse"/>
+            <element ref="saml:ProxyRestriction"/>
+        </choice>
+        <attribute name="NotBefore" type="dateTime" use="optional"/>
+        <attribute name="NotOnOrAfter" type="dateTime" use="optional"/>
+    </complexType>
+    <element name="Condition" type="saml:ConditionAbstractType"/>
+    <complexType name="ConditionAbstractType" abstract="true"/>
+    <element name="AudienceRestriction" type="saml:AudienceRestrictionType"/>
+    <complexType name="AudienceRestrictionType">
+        <complexContent>
+            <extension base="saml:ConditionAbstractType">
+                <sequence>
+                    <element ref="saml:Audience" maxOccurs="unbounded"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="Audience" type="anyURI"/>
+    <element name="OneTimeUse" type="saml:OneTimeUseType" />
+    <complexType name="OneTimeUseType">
+        <complexContent>
+            <extension base="saml:ConditionAbstractType"/>
+        </complexContent>
+    </complexType>
+    <element name="ProxyRestriction" type="saml:ProxyRestrictionType"/>
+    <complexType name="ProxyRestrictionType">
+    <complexContent>
+        <extension base="saml:ConditionAbstractType">
+            <sequence>
+                <element ref="saml:Audience" minOccurs="0" maxOccurs="unbounded"/>
+            </sequence>
+            <attribute name="Count" type="nonNegativeInteger" use="optional"/>
+        </extension>
+	</complexContent>
+    </complexType>
+    <element name="Advice" type="saml:AdviceType"/>
+    <complexType name="AdviceType">
+        <choice minOccurs="0" maxOccurs="unbounded">
+            <element ref="saml:AssertionIDRef"/>
+            <element ref="saml:AssertionURIRef"/>
+            <element ref="saml:Assertion"/>
+            <element ref="saml:EncryptedAssertion"/>
+            <any namespace="##other" processContents="lax"/>
+        </choice>
+    </complexType>
+    <element name="EncryptedAssertion" type="saml:EncryptedElementType"/>
+    <element name="Statement" type="saml:StatementAbstractType"/>
+    <complexType name="StatementAbstractType" abstract="true"/>
+    <element name="AuthnStatement" type="saml:AuthnStatementType"/>
+    <complexType name="AuthnStatementType">
+        <complexContent>
+            <extension base="saml:StatementAbstractType">
+                <sequence>
+                    <element ref="saml:SubjectLocality" minOccurs="0"/>
+                    <element ref="saml:AuthnContext"/>
+                </sequence>
+                <attribute name="AuthnInstant" type="dateTime" use="required"/>
+                <attribute name="SessionIndex" type="string" use="optional"/>
+                <attribute name="SessionNotOnOrAfter" type="dateTime" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="SubjectLocality" type="saml:SubjectLocalityType"/>
+    <complexType name="SubjectLocalityType">
+        <attribute name="Address" type="string" use="optional"/>
+        <attribute name="DNSName" type="string" use="optional"/>
+    </complexType>
+    <element name="AuthnContext" type="saml:AuthnContextType"/>
+    <complexType name="AuthnContextType">
+        <sequence>
+            <choice>
+                <sequence>
+                    <element ref="saml:AuthnContextClassRef"/>
+                    <choice minOccurs="0">
+                        <element ref="saml:AuthnContextDecl"/>
+                        <element ref="saml:AuthnContextDeclRef"/>
+                    </choice>
+                </sequence>
+                <choice>
+                    <element ref="saml:AuthnContextDecl"/>
+                    <element ref="saml:AuthnContextDeclRef"/>
+                </choice>
+            </choice>
+            <element ref="saml:AuthenticatingAuthority" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+    </complexType>
+    <element name="AuthnContextClassRef" type="anyURI"/>
+    <element name="AuthnContextDeclRef" type="anyURI"/>
+    <element name="AuthnContextDecl" type="anyType"/>
+    <element name="AuthenticatingAuthority" type="anyURI"/>
+    <element name="AuthzDecisionStatement" type="saml:AuthzDecisionStatementType"/>
+    <complexType name="AuthzDecisionStatementType">
+        <complexContent>
+            <extension base="saml:StatementAbstractType">
+                <sequence>
+                    <element ref="saml:Action" maxOccurs="unbounded"/>
+                    <element ref="saml:Evidence" minOccurs="0"/>
+                </sequence>
+                <attribute name="Resource" type="anyURI" use="required"/>
+                <attribute name="Decision" type="saml:DecisionType" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <simpleType name="DecisionType">
+        <restriction base="string">
+            <enumeration value="Permit"/>
+            <enumeration value="Deny"/>
+            <enumeration value="Indeterminate"/>
+        </restriction>
+    </simpleType>
+    <element name="Action" type="saml:ActionType"/>
+    <complexType name="ActionType">
+        <simpleContent>
+            <extension base="string">
+                <attribute name="Namespace" type="anyURI" use="required"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <element name="Evidence" type="saml:EvidenceType"/>
+    <complexType name="EvidenceType">
+        <choice maxOccurs="unbounded">
+            <element ref="saml:AssertionIDRef"/>
+            <element ref="saml:AssertionURIRef"/>
+            <element ref="saml:Assertion"/>
+            <element ref="saml:EncryptedAssertion"/>
+        </choice>
+    </complexType>
+    <element name="AttributeStatement" type="saml:AttributeStatementType"/>
+    <complexType name="AttributeStatementType">
+        <complexContent>
+            <extension base="saml:StatementAbstractType">
+                <choice maxOccurs="unbounded">
+                    <element ref="saml:Attribute"/>
+                    <element ref="saml:EncryptedAttribute"/>
+                </choice>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="Attribute" type="saml:AttributeType"/>
+    <complexType name="AttributeType">
+        <sequence>
+            <element ref="saml:AttributeValue" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+        <attribute name="Name" type="string" use="required"/>
+        <attribute name="NameFormat" type="anyURI" use="optional"/>
+        <attribute name="FriendlyName" type="string" use="optional"/>
+        <anyAttribute namespace="##other" processContents="lax"/>
+    </complexType>
+    <element name="AttributeValue" type="anyType" nillable="true"/>
+    <element name="EncryptedAttribute" type="saml:EncryptedElementType"/>
+</schema>

--- a/spec/support/schema/saml-schema-metadata-2.0.xsd
+++ b/spec/support/schema/saml-schema-metadata-2.0.xsd
@@ -1,0 +1,300 @@
+<?xml version="1.0"?>
+<schema xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:oasis:names:tc:SAML:2.0:metadata" elementFormDefault="unqualified" attributeFormDefault="unqualified" blockDefault="substitution" version="2.0">
+  <import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd"/>
+  <import namespace="http://www.w3.org/2001/04/xmlenc#" schemaLocation="xenc-schema.xsd"/>
+  <import namespace="urn:oasis:names:tc:SAML:2.0:assertion" schemaLocation="saml-schema-assertion-2.0.xsd"/>
+  <import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <annotation>
+    <documentation> Document identifier: saml-schema-metadata-2.0 Location: http://docs.oasis-open.org/security/saml/v2.0/ Revision history: V2.0 (March, 2005): Schema for SAML metadata, first published in SAML 2.0. </documentation>
+  </annotation>
+  <simpleType name="entityIDType">
+    <restriction base="anyURI">
+      <maxLength value="1024"/>
+    </restriction>
+  </simpleType>
+  <complexType name="localizedNameType">
+    <simpleContent>
+      <extension base="string">
+        <attribute ref="xml:lang" use="required"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <complexType name="localizedURIType">
+    <simpleContent>
+      <extension base="anyURI">
+        <attribute ref="xml:lang" use="required"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <element name="Extensions" type="md:ExtensionsType"/>
+  <complexType final="#all" name="ExtensionsType">
+    <sequence>
+      <any namespace="##other" processContents="lax" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+  <complexType name="EndpointType">
+    <sequence>
+      <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="Binding" type="anyURI" use="required"/>
+    <attribute name="Location" type="anyURI" use="required"/>
+    <attribute name="ResponseLocation" type="anyURI" use="optional"/>
+    <anyAttribute namespace="##other" processContents="lax"/>
+  </complexType>
+  <complexType name="IndexedEndpointType">
+    <complexContent>
+      <extension base="md:EndpointType">
+        <attribute name="index" type="unsignedShort" use="required"/>
+        <attribute name="isDefault" type="boolean" use="optional"/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="EntitiesDescriptor" type="md:EntitiesDescriptorType"/>
+  <complexType name="EntitiesDescriptorType">
+    <sequence>
+      <element ref="ds:Signature" minOccurs="0"/>
+      <element ref="md:Extensions" minOccurs="0"/>
+      <choice minOccurs="1" maxOccurs="unbounded">
+        <element ref="md:EntityDescriptor"/>
+        <element ref="md:EntitiesDescriptor"/>
+      </choice>
+    </sequence>
+    <attribute name="validUntil" type="dateTime" use="optional"/>
+    <attribute name="cacheDuration" type="duration" use="optional"/>
+    <attribute name="ID" type="ID" use="optional"/>
+    <attribute name="Name" type="string" use="optional"/>
+  </complexType>
+  <element name="EntityDescriptor" type="md:EntityDescriptorType"/>
+  <complexType name="EntityDescriptorType">
+    <sequence>
+      <element ref="ds:Signature" minOccurs="0"/>
+      <element ref="md:Extensions" minOccurs="0"/>
+      <choice>
+        <choice maxOccurs="unbounded">
+          <element ref="md:RoleDescriptor"/>
+          <element ref="md:IDPSSODescriptor"/>
+          <element ref="md:SPSSODescriptor"/>
+          <element ref="md:AuthnAuthorityDescriptor"/>
+          <element ref="md:AttributeAuthorityDescriptor"/>
+          <element ref="md:PDPDescriptor"/>
+        </choice>
+        <element ref="md:AffiliationDescriptor"/>
+      </choice>
+      <element ref="md:Organization" minOccurs="0"/>
+      <element ref="md:ContactPerson" minOccurs="0" maxOccurs="unbounded"/>
+      <element ref="md:AdditionalMetadataLocation" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="entityID" type="md:entityIDType" use="required"/>
+    <attribute name="validUntil" type="dateTime" use="optional"/>
+    <attribute name="cacheDuration" type="duration" use="optional"/>
+    <attribute name="ID" type="ID" use="optional"/>
+    <anyAttribute namespace="##other" processContents="lax"/>
+  </complexType>
+  <element name="Organization" type="md:OrganizationType"/>
+  <complexType name="OrganizationType">
+    <sequence>
+      <element ref="md:Extensions" minOccurs="0"/>
+      <element ref="md:OrganizationName" maxOccurs="unbounded"/>
+      <element ref="md:OrganizationDisplayName" maxOccurs="unbounded"/>
+      <element ref="md:OrganizationURL" maxOccurs="unbounded"/>
+    </sequence>
+    <anyAttribute namespace="##other" processContents="lax"/>
+  </complexType>
+  <element name="OrganizationName" type="md:localizedNameType"/>
+  <element name="OrganizationDisplayName" type="md:localizedNameType"/>
+  <element name="OrganizationURL" type="md:localizedURIType"/>
+  <element name="ContactPerson" type="md:ContactType"/>
+  <complexType name="ContactType">
+    <sequence>
+      <element ref="md:Extensions" minOccurs="0"/>
+      <element ref="md:Company" minOccurs="0"/>
+      <element ref="md:GivenName" minOccurs="0"/>
+      <element ref="md:SurName" minOccurs="0"/>
+      <element ref="md:EmailAddress" minOccurs="0" maxOccurs="unbounded"/>
+      <element ref="md:TelephoneNumber" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="contactType" type="md:ContactTypeType" use="required"/>
+    <anyAttribute namespace="##other" processContents="lax"/>
+  </complexType>
+  <element name="Company" type="string"/>
+  <element name="GivenName" type="string"/>
+  <element name="SurName" type="string"/>
+  <element name="EmailAddress" type="anyURI"/>
+  <element name="TelephoneNumber" type="string"/>
+  <simpleType name="ContactTypeType">
+    <restriction base="string">
+      <enumeration value="technical"/>
+      <enumeration value="support"/>
+      <enumeration value="administrative"/>
+      <enumeration value="billing"/>
+      <enumeration value="other"/>
+    </restriction>
+  </simpleType>
+  <element name="AdditionalMetadataLocation" type="md:AdditionalMetadataLocationType"/>
+  <complexType name="AdditionalMetadataLocationType">
+    <simpleContent>
+      <extension base="anyURI">
+        <attribute name="namespace" type="anyURI" use="required"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <element name="RoleDescriptor" type="md:RoleDescriptorType"/>
+  <complexType name="RoleDescriptorType" abstract="true">
+    <sequence>
+      <element ref="ds:Signature" minOccurs="0"/>
+      <element ref="md:Extensions" minOccurs="0"/>
+      <element ref="md:KeyDescriptor" minOccurs="0" maxOccurs="unbounded"/>
+      <element ref="md:Organization" minOccurs="0"/>
+      <element ref="md:ContactPerson" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="ID" type="ID" use="optional"/>
+    <attribute name="validUntil" type="dateTime" use="optional"/>
+    <attribute name="cacheDuration" type="duration" use="optional"/>
+    <attribute name="protocolSupportEnumeration" type="md:anyURIListType" use="required"/>
+    <attribute name="errorURL" type="anyURI" use="optional"/>
+    <anyAttribute namespace="##other" processContents="lax"/>
+  </complexType>
+  <simpleType name="anyURIListType">
+    <list itemType="anyURI"/>
+  </simpleType>
+  <element name="KeyDescriptor" type="md:KeyDescriptorType"/>
+  <complexType name="KeyDescriptorType">
+    <sequence>
+      <element ref="ds:KeyInfo"/>
+      <element ref="md:EncryptionMethod" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="use" type="md:KeyTypes" use="optional"/>
+  </complexType>
+  <simpleType name="KeyTypes">
+    <restriction base="string">
+      <enumeration value="encryption"/>
+      <enumeration value="signing"/>
+    </restriction>
+  </simpleType>
+  <element name="EncryptionMethod" type="xenc:EncryptionMethodType"/>
+  <complexType name="SSODescriptorType" abstract="true">
+    <complexContent>
+      <extension base="md:RoleDescriptorType">
+        <sequence>
+          <element ref="md:ArtifactResolutionService" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="md:SingleLogoutService" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="md:ManageNameIDService" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="md:NameIDFormat" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ArtifactResolutionService" type="md:IndexedEndpointType"/>
+  <element name="SingleLogoutService" type="md:EndpointType"/>
+  <element name="ManageNameIDService" type="md:EndpointType"/>
+  <element name="NameIDFormat" type="anyURI"/>
+  <element name="IDPSSODescriptor" type="md:IDPSSODescriptorType"/>
+  <complexType name="IDPSSODescriptorType">
+    <complexContent>
+      <extension base="md:SSODescriptorType">
+        <sequence>
+          <element ref="md:SingleSignOnService" maxOccurs="unbounded"/>
+          <element ref="md:NameIDMappingService" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="md:AssertionIDRequestService" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="md:AttributeProfile" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="saml:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+        <attribute name="WantAuthnRequestsSigned" type="boolean" use="optional"/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="SingleSignOnService" type="md:EndpointType"/>
+  <element name="NameIDMappingService" type="md:EndpointType"/>
+  <element name="AssertionIDRequestService" type="md:EndpointType"/>
+  <element name="AttributeProfile" type="anyURI"/>
+  <element name="SPSSODescriptor" type="md:SPSSODescriptorType"/>
+  <complexType name="SPSSODescriptorType">
+    <complexContent>
+      <extension base="md:SSODescriptorType">
+        <sequence>
+          <element ref="md:AssertionConsumerService" maxOccurs="unbounded"/>
+          <element ref="md:AttributeConsumingService" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+        <attribute name="AuthnRequestsSigned" type="boolean" use="optional"/>
+        <attribute name="WantAssertionsSigned" type="boolean" use="optional"/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="AssertionConsumerService" type="md:IndexedEndpointType"/>
+  <element name="AttributeConsumingService" type="md:AttributeConsumingServiceType"/>
+  <complexType name="AttributeConsumingServiceType">
+    <sequence>
+      <element ref="md:ServiceName" maxOccurs="unbounded"/>
+      <element ref="md:ServiceDescription" minOccurs="0" maxOccurs="unbounded"/>
+      <element ref="md:RequestedAttribute" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="index" type="unsignedShort" use="required"/>
+    <attribute name="isDefault" type="boolean" use="optional"/>
+  </complexType>
+  <element name="ServiceName" type="md:localizedNameType"/>
+  <element name="ServiceDescription" type="md:localizedNameType"/>
+  <element name="RequestedAttribute" type="md:RequestedAttributeType"/>
+  <complexType name="RequestedAttributeType">
+    <complexContent>
+      <extension base="saml:AttributeType">
+        <attribute name="isRequired" type="boolean" use="optional"/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="AuthnAuthorityDescriptor" type="md:AuthnAuthorityDescriptorType"/>
+  <complexType name="AuthnAuthorityDescriptorType">
+    <complexContent>
+      <extension base="md:RoleDescriptorType">
+        <sequence>
+          <element ref="md:AuthnQueryService" maxOccurs="unbounded"/>
+          <element ref="md:AssertionIDRequestService" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="md:NameIDFormat" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="AuthnQueryService" type="md:EndpointType"/>
+  <element name="PDPDescriptor" type="md:PDPDescriptorType"/>
+  <complexType name="PDPDescriptorType">
+    <complexContent>
+      <extension base="md:RoleDescriptorType">
+        <sequence>
+          <element ref="md:AuthzService" maxOccurs="unbounded"/>
+          <element ref="md:AssertionIDRequestService" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="md:NameIDFormat" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="AuthzService" type="md:EndpointType"/>
+  <element name="AttributeAuthorityDescriptor" type="md:AttributeAuthorityDescriptorType"/>
+  <complexType name="AttributeAuthorityDescriptorType">
+    <complexContent>
+      <extension base="md:RoleDescriptorType">
+        <sequence>
+          <element ref="md:AttributeService" maxOccurs="unbounded"/>
+          <element ref="md:AssertionIDRequestService" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="md:NameIDFormat" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="md:AttributeProfile" minOccurs="0" maxOccurs="unbounded"/>
+          <element ref="saml:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="AttributeService" type="md:EndpointType"/>
+  <element name="AffiliationDescriptor" type="md:AffiliationDescriptorType"/>
+  <complexType name="AffiliationDescriptorType">
+    <sequence>
+      <element ref="ds:Signature" minOccurs="0"/>
+      <element ref="md:Extensions" minOccurs="0"/>
+      <element ref="md:AffiliateMember" maxOccurs="unbounded"/>
+      <element ref="md:KeyDescriptor" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="affiliationOwnerID" type="md:entityIDType" use="required"/>
+    <attribute name="validUntil" type="dateTime" use="optional"/>
+    <attribute name="cacheDuration" type="duration" use="optional"/>
+    <attribute name="ID" type="ID" use="optional"/>
+    <anyAttribute namespace="##other" processContents="lax"/>
+  </complexType>
+  <element name="AffiliateMember" type="md:entityIDType"/>
+</schema>

--- a/spec/support/schema/xenc-schema.xsd
+++ b/spec/support/schema/xenc-schema.xsd
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE schema  PUBLIC "-//W3C//DTD XMLSchema 200102//EN"
+ "http://www.w3.org/2001/XMLSchema.dtd"
+ [
+   <!ATTLIST schema
+     xmlns:xenc CDATA #FIXED 'http://www.w3.org/2001/04/xmlenc#'
+     xmlns:ds CDATA #FIXED 'http://www.w3.org/2000/09/xmldsig#'>
+   <!ENTITY xenc 'http://www.w3.org/2001/04/xmlenc#'>
+   <!ENTITY % p ''>
+   <!ENTITY % s ''>
+  ]>
+
+<schema xmlns='http://www.w3.org/2001/XMLSchema' version='1.0'
+        xmlns:xenc='http://www.w3.org/2001/04/xmlenc#'
+        xmlns:ds='http://www.w3.org/2000/09/xmldsig#'
+        targetNamespace='http://www.w3.org/2001/04/xmlenc#'
+        elementFormDefault='qualified'>
+
+  <import namespace='http://www.w3.org/2000/09/xmldsig#'
+          schemaLocation='xmldsig-core-schema.xsd'/>
+
+  <complexType name='EncryptedType' abstract='true'>
+    <sequence>
+      <element name='EncryptionMethod' type='xenc:EncryptionMethodType'
+       minOccurs='0'/>
+      <element ref='ds:KeyInfo' minOccurs='0'/>
+      <element ref='xenc:CipherData'/>
+      <element ref='xenc:EncryptionProperties' minOccurs='0'/>
+    </sequence>
+    <attribute name='Id' type='ID' use='optional'/>
+    <attribute name='Type' type='anyURI' use='optional'/>
+    <attribute name='MimeType' type='string' use='optional'/>
+    <attribute name='Encoding' type='anyURI' use='optional'/>
+  </complexType>
+
+  <complexType name='EncryptionMethodType' mixed='true'>
+    <sequence>
+      <element name='KeySize' minOccurs='0' type='xenc:KeySizeType'/>
+      <element name='OAEPparams' minOccurs='0' type='base64Binary'/>
+      <any namespace='##other' minOccurs='0' maxOccurs='unbounded'/>
+    </sequence>
+    <attribute name='Algorithm' type='anyURI' use='required'/>
+  </complexType>
+
+    <simpleType name='KeySizeType'>
+      <restriction base="integer"/>
+    </simpleType>
+
+  <element name='CipherData' type='xenc:CipherDataType'/>
+  <complexType name='CipherDataType'>
+     <choice>
+       <element name='CipherValue' type='base64Binary'/>
+       <element ref='xenc:CipherReference'/>
+     </choice>
+    </complexType>
+
+   <element name='CipherReference' type='xenc:CipherReferenceType'/>
+   <complexType name='CipherReferenceType'>
+       <choice>
+         <element name='Transforms' type='xenc:TransformsType' minOccurs='0'/>
+       </choice>
+       <attribute name='URI' type='anyURI' use='required'/>
+   </complexType>
+
+     <complexType name='TransformsType'>
+       <sequence>
+         <element ref='ds:Transform' maxOccurs='unbounded'/>
+       </sequence>
+     </complexType>
+
+
+  <element name='EncryptedData' type='xenc:EncryptedDataType'/>
+  <complexType name='EncryptedDataType'>
+    <complexContent>
+      <extension base='xenc:EncryptedType'>
+       </extension>
+    </complexContent>
+  </complexType>
+
+  <!-- Children of ds:KeyInfo -->
+
+  <element name='EncryptedKey' type='xenc:EncryptedKeyType'/>
+  <complexType name='EncryptedKeyType'>
+    <complexContent>
+      <extension base='xenc:EncryptedType'>
+        <sequence>
+          <element ref='xenc:ReferenceList' minOccurs='0'/>
+          <element name='CarriedKeyName' type='string' minOccurs='0'/>
+        </sequence>
+        <attribute name='Recipient' type='string'
+         use='optional'/>
+      </extension>
+    </complexContent>
+  </complexType>
+
+    <element name="AgreementMethod" type="xenc:AgreementMethodType"/>
+    <complexType name="AgreementMethodType" mixed="true">
+      <sequence>
+        <element name="KA-Nonce" minOccurs="0" type="base64Binary"/>
+        <!-- <element ref="ds:DigestMethod" minOccurs="0"/> -->
+        <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+        <element name="OriginatorKeyInfo" minOccurs="0" type="ds:KeyInfoType"/>
+        <element name="RecipientKeyInfo" minOccurs="0" type="ds:KeyInfoType"/>
+      </sequence>
+      <attribute name="Algorithm" type="anyURI" use="required"/>
+    </complexType>
+
+  <!-- End Children of ds:KeyInfo -->
+
+  <element name='ReferenceList'>
+    <complexType>
+      <choice minOccurs='1' maxOccurs='unbounded'>
+        <element name='DataReference' type='xenc:ReferenceType'/>
+        <element name='KeyReference' type='xenc:ReferenceType'/>
+      </choice>
+    </complexType>
+  </element>
+
+  <complexType name='ReferenceType'>
+    <sequence>
+      <any namespace='##other' minOccurs='0' maxOccurs='unbounded'/>
+    </sequence>
+    <attribute name='URI' type='anyURI' use='required'/>
+  </complexType>
+
+
+  <element name='EncryptionProperties' type='xenc:EncryptionPropertiesType'/>
+  <complexType name='EncryptionPropertiesType'>
+    <sequence>
+      <element ref='xenc:EncryptionProperty' maxOccurs='unbounded'/>
+    </sequence>
+    <attribute name='Id' type='ID' use='optional'/>
+  </complexType>
+
+    <element name='EncryptionProperty' type='xenc:EncryptionPropertyType'/>
+    <complexType name='EncryptionPropertyType' mixed='true'>
+      <choice maxOccurs='unbounded'>
+        <any namespace='##other' processContents='lax'/>
+      </choice>
+      <attribute name='Target' type='anyURI' use='optional'/>
+      <attribute name='Id' type='ID' use='optional'/>
+      <anyAttribute namespace="http://www.w3.org/XML/1998/namespace"/>
+    </complexType>
+
+</schema>
+

--- a/spec/support/schema/xml.xsd
+++ b/spec/support/schema/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/spec/support/schema/xmldsig-core-schema.xsd
+++ b/spec/support/schema/xmldsig-core-schema.xsd
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE schema
+  PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd"
+ [
+   <!ATTLIST schema 
+     xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
+   <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
+   <!ENTITY % p ''>
+   <!ENTITY % s ''>
+  ]>
+
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+        targetNamespace="http://www.w3.org/2000/09/xmldsig#"
+        version="0.1" elementFormDefault="qualified"> 
+
+<!-- Basic Types Defined for Signatures -->
+
+<simpleType name="CryptoBinary">
+  <restriction base="base64Binary">
+  </restriction>
+</simpleType>
+
+<!-- Start Signature -->
+
+<element name="Signature" type="ds:SignatureType"/>
+<complexType name="SignatureType">
+  <sequence> 
+    <element ref="ds:SignedInfo"/> 
+    <element ref="ds:SignatureValue"/> 
+    <element ref="ds:KeyInfo" minOccurs="0"/> 
+    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="SignatureValue" type="ds:SignatureValueType"/> 
+  <complexType name="SignatureValueType">
+    <simpleContent>
+      <extension base="base64Binary">
+        <attribute name="Id" type="ID" use="optional"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+
+<!-- Start SignedInfo -->
+
+<element name="SignedInfo" type="ds:SignedInfoType"/>
+<complexType name="SignedInfoType">
+  <sequence> 
+    <element ref="ds:CanonicalizationMethod"/> 
+    <element ref="ds:SignatureMethod"/> 
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/> 
+  <complexType name="CanonicalizationMethodType" mixed="true">
+    <sequence>
+      <any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+  <element name="SignatureMethod" type="ds:SignatureMethodType"/>
+  <complexType name="SignatureMethodType" mixed="true">
+    <sequence>
+      <element name="HMACOutputLength" minOccurs="0" type="ds:HMACOutputLengthType"/>
+      <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) external namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- Start Reference -->
+
+<element name="Reference" type="ds:ReferenceType"/>
+<complexType name="ReferenceType">
+  <sequence> 
+    <element ref="ds:Transforms" minOccurs="0"/> 
+    <element ref="ds:DigestMethod"/> 
+    <element ref="ds:DigestValue"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="URI" type="anyURI" use="optional"/> 
+  <attribute name="Type" type="anyURI" use="optional"/> 
+</complexType>
+
+  <element name="Transforms" type="ds:TransformsType"/>
+  <complexType name="TransformsType">
+    <sequence>
+      <element ref="ds:Transform" maxOccurs="unbounded"/>  
+    </sequence>
+  </complexType>
+
+  <element name="Transform" type="ds:TransformType"/>
+  <complexType name="TransformType" mixed="true">
+    <choice minOccurs="0" maxOccurs="unbounded"> 
+      <any namespace="##other" processContents="lax"/>
+      <!-- (1,1) elements from (0,unbounded) namespaces -->
+      <element name="XPath" type="string"/> 
+    </choice>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- End Reference -->
+
+<element name="DigestMethod" type="ds:DigestMethodType"/>
+<complexType name="DigestMethodType" mixed="true"> 
+  <sequence>
+    <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>    
+  <attribute name="Algorithm" type="anyURI" use="required"/> 
+</complexType>
+
+<element name="DigestValue" type="ds:DigestValueType"/>
+<simpleType name="DigestValueType">
+  <restriction base="base64Binary"/>
+</simpleType>
+
+<!-- End SignedInfo -->
+
+<!-- Start KeyInfo -->
+
+<element name="KeyInfo" type="ds:KeyInfoType"/> 
+<complexType name="KeyInfoType" mixed="true">
+  <choice maxOccurs="unbounded">     
+    <element ref="ds:KeyName"/> 
+    <element ref="ds:KeyValue"/> 
+    <element ref="ds:RetrievalMethod"/> 
+    <element ref="ds:X509Data"/> 
+    <element ref="ds:PGPData"/> 
+    <element ref="ds:SPKIData"/>
+    <element ref="ds:MgmtData"/>
+    <any processContents="lax" namespace="##other"/>
+    <!-- (1,1) elements from (0,unbounded) namespaces -->
+  </choice>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="KeyName" type="string"/>
+  <element name="MgmtData" type="string"/>
+
+  <element name="KeyValue" type="ds:KeyValueType"/> 
+  <complexType name="KeyValueType" mixed="true">
+   <choice>
+     <element ref="ds:DSAKeyValue"/>
+     <element ref="ds:RSAKeyValue"/>
+     <any namespace="##other" processContents="lax"/>
+   </choice>
+  </complexType>
+
+  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/> 
+  <complexType name="RetrievalMethodType">
+    <sequence>
+      <element ref="ds:Transforms" minOccurs="0"/> 
+    </sequence>  
+    <attribute name="URI" type="anyURI"/>
+    <attribute name="Type" type="anyURI" use="optional"/>
+  </complexType>
+
+<!-- Start X509Data -->
+
+<element name="X509Data" type="ds:X509DataType"/> 
+<complexType name="X509DataType">
+  <sequence maxOccurs="unbounded">
+    <choice>
+      <element name="X509IssuerSerial" type="ds:X509IssuerSerialType"/>
+      <element name="X509SKI" type="base64Binary"/>
+      <element name="X509SubjectName" type="string"/>
+      <element name="X509Certificate" type="base64Binary"/>
+      <element name="X509CRL" type="base64Binary"/>
+      <any namespace="##other" processContents="lax"/>
+    </choice>
+  </sequence>
+</complexType>
+
+<complexType name="X509IssuerSerialType"> 
+  <sequence> 
+    <element name="X509IssuerName" type="string"/> 
+    <element name="X509SerialNumber" type="integer"/> 
+  </sequence>
+</complexType>
+
+<!-- End X509Data -->
+
+<!-- Begin PGPData -->
+
+<element name="PGPData" type="ds:PGPDataType"/> 
+<complexType name="PGPDataType"> 
+  <choice>
+    <sequence>
+      <element name="PGPKeyID" type="base64Binary"/> 
+      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+    <sequence>
+      <element name="PGPKeyPacket" type="base64Binary"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+  </choice>
+</complexType>
+
+<!-- End PGPData -->
+
+<!-- Begin SPKIData -->
+
+<element name="SPKIData" type="ds:SPKIDataType"/> 
+<complexType name="SPKIDataType">
+  <sequence maxOccurs="unbounded">
+    <element name="SPKISexp" type="base64Binary"/>
+    <any namespace="##other" processContents="lax" minOccurs="0"/>
+  </sequence>
+</complexType> 
+
+<!-- End SPKIData -->
+
+<!-- End KeyInfo -->
+
+<!-- Start Object (Manifest, SignatureProperty) -->
+
+<element name="Object" type="ds:ObjectType"/> 
+<complexType name="ObjectType" mixed="true">
+  <sequence minOccurs="0" maxOccurs="unbounded">
+    <any namespace="##any" processContents="lax"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="MimeType" type="string" use="optional"/> <!-- add a grep facet -->
+  <attribute name="Encoding" type="anyURI" use="optional"/> 
+</complexType>
+
+<element name="Manifest" type="ds:ManifestType"/> 
+<complexType name="ManifestType">
+  <sequence>
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+<element name="SignatureProperties" type="ds:SignaturePropertiesType"/> 
+<complexType name="SignaturePropertiesType">
+  <sequence>
+    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+   <element name="SignatureProperty" type="ds:SignaturePropertyType"/> 
+   <complexType name="SignaturePropertyType" mixed="true">
+     <choice maxOccurs="unbounded">
+       <any namespace="##other" processContents="lax"/>
+       <!-- (1,1) elements from (1,unbounded) namespaces -->
+     </choice>
+     <attribute name="Target" type="anyURI" use="required"/> 
+     <attribute name="Id" type="ID" use="optional"/> 
+   </complexType>
+
+<!-- End Object (Manifest, SignatureProperty) -->
+
+<!-- Start Algorithm Parameters -->
+
+<simpleType name="HMACOutputLengthType">
+  <restriction base="integer"/>
+</simpleType>
+
+<!-- Start KeyValue Element-types -->
+
+<element name="DSAKeyValue" type="ds:DSAKeyValueType"/>
+<complexType name="DSAKeyValueType">
+  <sequence>
+    <sequence minOccurs="0">
+      <element name="P" type="ds:CryptoBinary"/>
+      <element name="Q" type="ds:CryptoBinary"/>
+    </sequence>
+    <element name="G" type="ds:CryptoBinary" minOccurs="0"/>
+    <element name="Y" type="ds:CryptoBinary"/>
+    <element name="J" type="ds:CryptoBinary" minOccurs="0"/>
+    <sequence minOccurs="0">
+      <element name="Seed" type="ds:CryptoBinary"/>
+      <element name="PgenCounter" type="ds:CryptoBinary"/>
+    </sequence>
+  </sequence>
+</complexType>
+
+<element name="RSAKeyValue" type="ds:RSAKeyValueType"/>
+<complexType name="RSAKeyValueType">
+  <sequence>
+    <element name="Modulus" type="ds:CryptoBinary"/> 
+    <element name="Exponent" type="ds:CryptoBinary"/> 
+  </sequence>
+</complexType> 
+
+<!-- End KeyValue Element-types -->
+
+<!-- End Signature -->
+
+</schema>


### PR DESCRIPTION
We got a partner ticket reporting a validation error with the SAML metadata document. Some of the elements were out of order.

I am curious if we think this may cause any issues for partners -- my assumption is that anyone using the metadata is accessing specific nodes. Should we be worried that someone is relying on the metadata order?

~Also -- I tried to set up a test for this using nokogiri, but was unable to get it to recognize all the namespaces. Would love guidance if anyone has worked with that before, as it seems like it would be good to have a test that validates the metadata against the schema. (I did validate the new order using xmllint on the command line)~ I was able to figure out how to do a validation test hooray