### PR TITLE
Remove unnecessary logging

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -11,7 +11,6 @@ module SamlIdp
       if raw
         log "#{'~' * 20} RAW Request #{'~' * 20}\n#{raw}\n#{'~' * 18} Done RAW Request #{'~' * 17}\n"
         decoded = Base64.decode64(raw.gsub(/\\r/, '').gsub(/\\n/, ''))
-        log "#{'~' * 20} Decoded Request #{'~' * 20}\n#{decoded}\n#{'~' * 18} Done Decoded Request #{'~' * 17}\n"
         zstream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
         begin
           inflated = zstream.inflate(decoded).tap do

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.19.2-18f'.freeze
+  VERSION = '0.19.3-18f'.freeze
 end


### PR DESCRIPTION
This was failing with messages of the form 'log writing failed. "\xB5" from ASCII-8BIT to UTF-8' as the logger was set up with binmode false.