### PR TITLE
Move matching_cert method to Request class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.19.3.pre.18f)
+    saml_idp (0.20.3.pre.18f)
       activesupport
       builder
       faraday

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -165,6 +165,17 @@ module SamlIdp
       errors.blank?
     end
 
+    def matching_cert
+      return nil unless signed?
+
+      Array(service_provider.certs).find do |cert|
+        document.valid_signature?(
+          OpenSSL::Digest::SHA256.new(cert.to_der).hexdigest,
+          options.merge(cert: cert)
+        )
+      end
+    end
+
     def signed?
       document.signed? || !!options[:get_params]&.key?(:Signature)
     end

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.20.2-18f'.freeze
+  VERSION = '0.20.3-18f'.freeze
 end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -416,12 +416,14 @@ module SamlIdp
         let(:cert) { saml_settings.get_sp_cert }
 
         describe 'the service provider has no registered certs' do
+          before { subject.service_provider.certs = [] }
+
           it 'returns nil' do
             expect(subject.matching_cert).to be nil
           end
         end
 
-        describe 'the service provider has one registered certs' do
+        describe 'the service provider has one registered cert' do
           before { subject.service_provider.certs = [cert] }
 
           describe 'the cert matches the assertion cert' do

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -397,6 +397,60 @@ module SamlIdp
       end
     end
 
+    describe '#matching_cert' do
+      let(:saml_request) { make_saml_request }
+
+      subject do
+        described_class.from_deflated_request saml_request
+      end
+
+      describe 'document is not signed' do
+        it 'returns nil' do
+          expect(subject.matching_cert).to be nil
+        end
+      end
+
+      describe 'document is signed' do
+        let(:saml_request) { signed_auth_request }
+        let(:service_provider)  { subject.service_provider }
+        let(:cert) { saml_settings.get_sp_cert }
+
+        describe 'the service provider has no registered certs' do
+          it 'returns nil' do
+            expect(subject.matching_cert).to be nil
+          end
+        end
+
+        describe 'the service provider has one registered certs' do
+          before { subject.service_provider.certs = [cert] }
+
+          describe 'the cert matches the assertion cert' do
+            it 'returns the cert' do
+              expect(subject.matching_cert).to eq cert
+            end
+          end
+
+          describe 'the cert does not match the assertion cert' do
+            let(:cert) { OpenSSL::X509::Certificate.new(cloudhsm_idp_x509_cert) }
+            it 'returns nil' do
+              expect(subject.matching_cert).to be nil
+            end
+          end
+
+        end
+
+        describe 'multiple certs' do
+          let(:not_matching_cert) { OpenSSL::X509::Certificate.new(cloudhsm_idp_x509_cert) }
+
+          before { subject.service_provider.certs = [not_matching_cert, invalid_cert, cert] }
+
+          it 'returns the matching cert' do
+            expect(subject.matching_cert).to eq cert
+          end
+        end
+      end
+    end
+
     def build_authn_context_classref(contexts)
       [contexts].flatten.map do |c|
         "<saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>#{c}</saml:AuthnContextClassRef>"


### PR DESCRIPTION
Relevant ticket:
https://gitlab.login.gov/lg-people/lg-people-appdev/protocols/saml/-/issues/8

The` matching_cert` value is currently a[ side effect](https://github.com/18F/saml_idp/blob/main/lib/saml_idp/service_provider.rb#L24) of the `valid_signature?` method. That means we have to run that method even if the SAML assertion is not signed.

Moving the `matching_cert` value into a method on the Request class will help unlock our ability to simplify some of that validation code (since we'll be able to better assume a digital signature exists)