### PR TITLE
LG-13312 Return an array from `#requested_vtr_authn_context`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.20.3.pre.18f)
+    saml_idp (0.21.0.pre.18f)
       activesupport
       builder
       faraday

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -102,7 +102,7 @@ module SamlIdp
       end.first
     end
 
-    def requested_vtr_authn_context
+    def requested_vtr_authn_contexts
       requested_authn_contexts.select do |classref|
         VTR_REGEXP.match?(classref)
       end

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -105,7 +105,7 @@ module SamlIdp
     def requested_vtr_authn_context
       requested_authn_contexts.select do |classref|
         VTR_REGEXP.match?(classref)
-      end.first
+      end
     end
 
     def acs_url

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.20.3-18f'.freeze
+  VERSION = '0.21.0-18f'.freeze
 end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -250,14 +250,14 @@ module SamlIdp
       end
     end
 
-    describe '#requested_vtr_authn_context' do
+    describe '#requested_vtr_authn_contexts' do
       subject { described_class.new raw_authn_request }
 
       context 'no vtr context requested' do
         let(:authn_context_classref) { '' }
 
-        it 'returns and empty array' do
-          expect(subject.requested_vtr_authn_context).to eq([])
+        it 'returns an empty array' do
+          expect(subject.requested_vtr_authn_contexts).to eq([])
         end
       end
 
@@ -265,7 +265,7 @@ module SamlIdp
         let(:authn_context_classref) { build_authn_context_classref(vtr) }
 
         it 'returns the vrt' do
-          expect(subject.requested_vtr_authn_context).to eq([vtr])
+          expect(subject.requested_vtr_authn_contexts).to eq([vtr])
         end
       end
 
@@ -273,7 +273,7 @@ module SamlIdp
         let(:authn_context_classref) { build_authn_context_classref([vtr, ial]) }
 
         it 'returns the vrt' do
-          expect(subject.requested_vtr_authn_context).to eq([vtr])
+          expect(subject.requested_vtr_authn_contexts).to eq([vtr])
         end
       end
 
@@ -281,7 +281,7 @@ module SamlIdp
         let(:authn_context_classref) { build_authn_context_classref(['C1.C2.P1.Pb', 'C1.C2.P1']) }
 
         it 'returns all of the vectors in an array' do
-          expect(subject.requested_vtr_authn_context).to eq(['C1.C2.P1.Pb', 'C1.C2.P1'])
+          expect(subject.requested_vtr_authn_contexts).to eq(['C1.C2.P1.Pb', 'C1.C2.P1'])
         end
       end
 
@@ -292,7 +292,7 @@ module SamlIdp
         end
 
         it 'does not match on the context' do
-          expect(subject.requested_vtr_authn_context).to eq([])
+          expect(subject.requested_vtr_authn_contexts).to eq([])
         end
       end
 
@@ -301,7 +301,7 @@ module SamlIdp
         let(:authn_context_classref) { build_authn_context_classref(aal) }
 
         it 'does not match on the context' do
-          expect(subject.requested_vtr_authn_context).to eq([])
+          expect(subject.requested_vtr_authn_contexts).to eq([])
         end
       end
     end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -256,8 +256,8 @@ module SamlIdp
       context 'no vtr context requested' do
         let(:authn_context_classref) { '' }
 
-        it 'returns nil' do
-          expect(subject.requested_vtr_authn_context).to be_nil
+        it 'returns and empty array' do
+          expect(subject.requested_vtr_authn_context).to eq([])
         end
       end
 
@@ -265,15 +265,23 @@ module SamlIdp
         let(:authn_context_classref) { build_authn_context_classref(vtr) }
 
         it 'returns the vrt' do
-          expect(subject.requested_vtr_authn_context).to eq(vtr)
+          expect(subject.requested_vtr_authn_context).to eq([vtr])
         end
       end
 
-      context 'multiple contexts including vtr' do
+      context 'multiple contexts including vtr and an old ACR context' do
         let(:authn_context_classref) { build_authn_context_classref([vtr, ial]) }
 
         it 'returns the vrt' do
-          expect(subject.requested_vtr_authn_context).to eq(vtr)
+          expect(subject.requested_vtr_authn_context).to eq([vtr])
+        end
+      end
+
+      context 'multiple contexts that are vectors of trust' do
+        let(:authn_context_classref) { build_authn_context_classref(['C1.C2.P1.Pb', 'C1.C2.P1']) }
+
+        it 'returns all of the vectors in an array' do
+          expect(subject.requested_vtr_authn_context).to eq(['C1.C2.P1.Pb', 'C1.C2.P1'])
         end
       end
 
@@ -284,7 +292,7 @@ module SamlIdp
         end
 
         it 'does not match on the context' do
-          expect(subject.requested_vtr_authn_context).to be_nil
+          expect(subject.requested_vtr_authn_context).to eq([])
         end
       end
 
@@ -293,7 +301,7 @@ module SamlIdp
         let(:authn_context_classref) { build_authn_context_classref(aal) }
 
         it 'does not match on the context' do
-          expect(subject.requested_vtr_authn_context).to be_nil
+          expect(subject.requested_vtr_authn_context).to eq([])
         end
       end
     end


### PR DESCRIPTION
The `Request#requested_vtr_authn_context` method returns the vectors of trust that appeared in `AuthnContextClassRef` nodes in the SAML request.

Service providers can send multiple vectors by adding additional `AuthnContextClassRef` nodes with vectors of trust in them. We initially managed this by selecting the first vector. However, we are interested in adding logic that selects an appropriate vector based on the user context. As a result we need to know all of the vectors that were passed in the SAML request.

This commit modifies the `Request#requested_vtr_authn_context` so that it returns all of the vectors in the SAML request in an array.