### PR TITLE
Add sig_namespace_hash to digest algorithm node

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.21.0.pre.18f)
+    saml_idp (0.21.1.pre.18f)
       activesupport
       builder
       faraday

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.21.0-18f'.freeze
+  VERSION = '0.21.1-18f'.freeze
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -209,11 +209,7 @@ module SamlIdp
             inclusive_namespaces
           )
 
-          digest_algorithm = algorithm(REXML::XPath.first(
-            ref,
-            '//ds:DigestMethod',
-            sig_namespace_hash
-          ))
+          digest_algorithm = digest_method_algorithm(ref, sig_namespace_hash)
 
           hash = digest_algorithm.digest(canon_hashed_element)
           digest_value = Base64.decode64(REXML::XPath.first(
@@ -242,6 +238,10 @@ module SamlIdp
 
         log '***** validate_doc_embedded_signature: verify_signature:'
         verify_signature(base64_cert, sig_alg, signature, canon_string, soft)
+      end
+
+      def digest_method_algorithm(ref, hash)
+        algorithm(REXML::XPath.first(ref, '//ds:DigestMethod', hash))
       end
 
       def verify_signature(base64_cert, sig_alg, signature, canon_string, soft)

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -209,7 +209,11 @@ module SamlIdp
             inclusive_namespaces
           )
 
-          digest_algorithm = algorithm(REXML::XPath.first(ref, '//ds:DigestMethod'))
+          digest_algorithm = algorithm(REXML::XPath.first(
+            ref,
+            '//ds:DigestMethod',
+            sig_namespace_hash
+          ))
 
           hash = digest_algorithm.digest(canon_hashed_element)
           digest_value = Base64.decode64(REXML::XPath.first(

--- a/spec/support/responses/no_ds_namespace.xml
+++ b/spec/support/responses/no_ds_namespace.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<samlp:AuthnRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_2b07dcbe-544a-4443-8199-fa45d91c1699" Version="2.0" IssueInstant="2024-05-28T16:49:52.266403Z" Destination="https://secure.login.gov/api/saml/auth2024" ForceAuthn="false" IsPassive="false" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://pbgccommercialazureprod.b2clogin.com/pbgccommercialazureprod.onmicrosoft.com/B2C_1A_TrustFrameworkBase/samlp/sso/assertionconsumer">
+  <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://login.example.com/issuer</Issuer>
+  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+    <SignedInfo>
+      <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <Reference URI="#_2b07dcbe-544a-4443-8199-fa45d91c1699">
+        <Transforms>
+          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <InclusiveNamespaces xmlns="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="saml samlp xenc xs"/>
+          </Transform>
+        </Transforms>
+        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <DigestValue>dsF6IkPLqWInTfs5omhiaIkns5m9KauWu26Fob69k9w=</DigestValue>
+      </Reference>
+    </SignedInfo>
+     <SignatureValue>MmuXQdjutiuP7soIaB7nk9wSR8OGkmyH5n9aelMTOrV7gTVNDazgQ/GXMmYXTTrhdvGN65duLO0oYdsYGxwNIjlA1lYhoGeBgYuIB/4iKZ6oLSDgjMcQxHkSW1OJ8pIEuUa/3MPUUjaSlTg0me4WRxVdXp34A9Mtlj0DgrK9m0A=</SignatureValue>
+    <KeyInfo>
+      <X509Data>
+        <X509Certificate>LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQwRENDQXptZ0F3SUJBZ0lCQVRBTkJna3Foa2lHOXcwQkFRVUZBRENCaGpFTE1Ba0dBMVVFQmhNQ1FWVXgKRERBS0JnTlZCQWdUQTA1VFZ6RVBNQTBHQTFVRUJ4TUdVM2xrYm1WNU1Rd3dDZ1lEVlFRS0RBTlFTVlF4Q1RBSApCZ05WQkFzTUFERVlNQllHQTFVRUF3d1BiR0YzY21WdVkyVndhWFF1WTI5dE1TVXdJd1lKS29aSWh2Y05BUWtCCkRCWnNZWGR5Wlc1alpTNXdhWFJBWjIxaGFXd3VZMjl0TUI0WERURXlNRFF4T0RBMU1qVTFPVm9YRFRNeU1EUXgKTXpBMU1qVTFPVm93Z1lZeEN6QUpCZ05WQkFZVEFrRlZNUXd3Q2dZRFZRUUlFd05PVTFjeER6QU5CZ05WQkFjVApCbE41Wkc1bGVURU1NQW9HQTFVRUNnd0RVRWxVTVFrd0J3WURWUVFMREFBeEdEQVdCZ05WQkFNTUQyeGhkM0psCmJtTmxjR2wwTG1OdmJURWxNQ01HQ1NxR1NJYjNEUUVKQVF3V2JHRjNjbVZ1WTJVdWNHbDBRR2R0WVdsc0xtTnYKYlRDQm56QU5CZ2txaGtpRzl3MEJBUUVGQUFPQmpRQXdnWWtDZ1lFQW9mR3p4NFZvQzZDSENYdFJPdkVLSFRzRAppNkFBWCtoVWpiSVloeERsZUxMZUNVemZDaVVXOFkwbTVrWkVKbjJXSmt5Si8wRFdPZmE5b0c1ZUg1eXNKSWpVCnpTUjVkMGJldmJZMEV1OHJDTmh3S001UzdYaXltTzBGc09mcnh6TkJxbVRBblE2VFJYT25nY1BYTitXRWd4cmQKZDVoV1V5ZXh2dkQ2d05McWdVRUNBd0VBQWFPQ0FVb3dnZ0ZHTUFrR0ExVWRFd1FDTUFBd0N3WURWUjBQQkFRRApBZ1VnTUIwR0ExVWREZ1FXQkJRMk1xTFZwRnlyVmNNaGFXMzRHanFkTVF6c3dqQVRCZ05WSFNVRUREQUtCZ2dyCkJnRUZCUWNEQVRCQ0JnbGdoa2dCaHZoQ0FRMEVOUll6VkdWemRDQllOVEE1SUdObGNuUWdZM0psWVhSbFpDQm0KYjNJZ1QyNWxURzluYVc0Z1lua2dUR0YzY21WdVkyVWdVR2wwTUlHekJnTlZIU01FZ2Fzd2dhaUFGRFl5b3RXawpYS3RWd3lGcGJmZ2FPcDB4RE96Q29ZR01wSUdKTUlHR01Rc3dDUVlEVlFRR0V3SkJWVEVNTUFvR0ExVUVDQk1EClRsTlhNUTh3RFFZRFZRUUhFd1pUZVdSdVpYa3hEREFLQmdOVkJBb01BMUJKVkRFSk1BY0dBMVVFQ3d3QU1SZ3cKRmdZRFZRUUREQTlzWVhkeVpXNWpaWEJwZEM1amIyMHhKVEFqQmdrcWhraUc5dzBCQ1FFTUZteGhkM0psYm1ObApMbkJwZEVCbmJXRnBiQzVqYjIyQ0FRRXdEUVlKS29aSWh2Y05BUUVGQlFBRGdZRUFOM2VRMUM5T0JJbVgvdWZGClNIUC9FeUxPQjJPQ1dqdlNpSytNbndQRWsralRRdDZZYXIxMkRacWVnRGhrWC92OGplTWh4VnpwaStBcHA4M0YKYWFmUE54UFJYc01FTFRCblhDQUJ1YzZEakxBaFlvNGQ4TDhCWUovVjlxLzZRMzdNYVZmc0ZKWVVKNmFBQUppWQpwd1RMUWJidFpqaytZc0s5TzZFR1U4ZjE5djg9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K</X509Certificate>
+      </X509Data>
+    </KeyInfo>
+  </Signature>
+  <samlp:RequestedAuthnContext>
+    <saml:AuthnContextClassRef>http://idmanagement.gov/ns/assurance/ial/1</saml:AuthnContextClassRef>
+    <saml:AuthnContextClassRef>http://idmanagement.gov/ns/requested_attributes?ReqAttr=email+phone+first_name+last_name+ssn</saml:AuthnContextClassRef>
+  </samlp:RequestedAuthnContext>
+</samlp:AuthnRequest>

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -61,7 +61,7 @@ module SamlIdp
 
     describe '#validate' do
       describe 'errors' do
-        it 'raises invalid certificates when the document ceritficate is invalid' do
+        it 'raises invalid certificates when the document certificate is invalid' do
           expect { document_with_invalid_certificate.validate('no:fi:ng:er:pr:in:t', false) }.to(
             raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError,
                         'Invalid certificate')
@@ -91,6 +91,37 @@ module SamlIdp
               'Certificate element present in response (ds:X509Certificate) but evaluating to nil'
             )
           )
+        end
+      end
+
+      describe '#digest_method_algorithm' do
+        let(:document) do
+          XMLSecurity::SignedDocument.new(fixture(:valid_sha256_no_ds_namespace, false))
+        end
+        let(:sig_namespace_hash) { { 'ds' => 'http://www.w3.org/2000/09/xmldsig#' } }
+
+        let(:el) do
+          REXML::XPath.first(
+            document,
+            '//ds:Signature',
+            sig_namespace_hash
+          )
+        end
+
+        let(:sig_element) do
+          REXML::XPath.first(el, '//ds:Reference', sig_namespace_hash)
+        end
+
+        let(:ref) do
+          REXML::XPath.first(sig_element, '//ds:Reference', sig_namespace_hash)
+        end
+
+        it 'returns the value in the DigestMethod node' do
+          expect(document.send(
+            :digest_method_algorithm,
+            ref,
+            sig_namespace_hash
+          )).to eq OpenSSL::Digest::SHA256
         end
       end
 

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -96,7 +96,7 @@ module SamlIdp
 
       describe '#digest_method_algorithm' do
         let(:document) do
-          XMLSecurity::SignedDocument.new(fixture(:valid_sha256_no_ds_namespace, false))
+          XMLSecurity::SignedDocument.new(fixture(:no_ds_namespace, false))
         end
         let(:sig_namespace_hash) { { 'ds' => 'http://www.w3.org/2000/09/xmldsig#' } }
 


### PR DESCRIPTION
When investigating a partner signature validation issue, I noticed this [commit](https://github.com/18F/saml_idp/commit/ee53c3194c81d4cec26da6c9ba55b02c63f79ad7) that updated our implementation to not require the `ds` namespacing. However,  `'//ds:DigestMethod'` node was not included, so when a SAML assertion does not include the `ds` namespace, our implementation is unable to identify the DigestMethod node to determine the correct digest algorithm. The algorithm then defaults to SHA1. If SHA1 is not the correct Digest algorithm, the IdP is unable to validate the signature.
