### PR TITLE
Allow option to track matching_cert bug fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.21.1.pre.18f)
+    saml_idp (0.21.2.pre.18f)
       activesupport
       builder
       faraday

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -171,7 +171,7 @@ module SamlIdp
       Array(service_provider.certs).find do |cert|
         document.valid_signature?(
           OpenSSL::Digest::SHA256.new(cert.to_der).hexdigest,
-          options.merge(cert:, no_namespace_enabled: true)
+          options.merge(cert:, digest_method_fix_enabled: true)
         )
       end
     end

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -171,7 +171,7 @@ module SamlIdp
       Array(service_provider.certs).find do |cert|
         document.valid_signature?(
           OpenSSL::Digest::SHA256.new(cert.to_der).hexdigest,
-          options.merge(cert:)
+          options.merge(cert:, no_namespace_enabled: true)
         )
       end
     end

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.21.1-18f'.freeze
+  VERSION = '0.21.2-18f'.freeze
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -214,10 +214,10 @@ module SamlIdp
           )
 
           digest_algorithm = if no_namespace_enabled
-              digest_method_algorithm(ref, sig_namespace_hash)
-            else
-              algorithm(REXML::XPath.first(ref, '//ds:DigestMethod'))
-            end
+            digest_method_algorithm(ref, sig_namespace_hash)
+          else
+            algorithm(REXML::XPath.first(ref, '//ds:DigestMethod'))
+          end
 
           hash = digest_algorithm.digest(canon_hashed_element)
           digest_value = Base64.decode64(REXML::XPath.first(

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -67,7 +67,7 @@ module SamlIdp
 
         let(:document) { XMLSecurity::SignedDocument.new(raw_xml) }
         let(:no_namespace_enabled) { true }
-        let(:options) {{ no_namespace_enabled: }}
+        let(:options) { { no_namespace_enabled: } }
 
         context 'no_namespace_enabled is set to true' do
           it 'validates the doc successfully' do

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -57,6 +57,32 @@ module SamlIdp
           )
         end
       end
+
+      describe 'options[:no_namespace_enabled]' do
+        let(:raw_xml) do
+          SamlIdp::Request.from_deflated_request(
+            signed_auth_request
+          ).raw_xml
+        end
+
+        let(:document) { XMLSecurity::SignedDocument.new(raw_xml) }
+        let(:no_namespace_enabled) { true }
+        let(:options) {{ no_namespace_enabled: }}
+
+        context 'no_namespace_enabled is set to true' do
+          it 'validates the doc successfully' do
+            expect(document.validate_doc(base64cert, true, options)).to be true
+          end
+        end
+
+        context 'no_namespace_enabled is set to false' do
+          let(:no_namespace_enabled) { false }
+
+          it 'validates the doc successfully' do
+            expect(document.validate_doc(base64cert, true, options)).to be true
+          end
+        end
+      end
     end
 
     describe '#validate' do
@@ -122,6 +148,16 @@ module SamlIdp
             ref,
             sig_namespace_hash
           )).to eq OpenSSL::Digest::SHA256
+        end
+
+        describe 'when the namespace hash is not defined' do
+          it 'returns the default algorithm type' do
+            expect(document.send(
+              :digest_method_algorithm,
+              ref,
+              {}
+            )).to eq OpenSSL::Digest::SHA1
+          end
         end
       end
 

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -58,7 +58,7 @@ module SamlIdp
         end
       end
 
-      describe 'options[:no_namespace_enabled]' do
+      describe 'options[:digest_method_fix_enabled]' do
         let(:raw_xml) do
           SamlIdp::Request.from_deflated_request(
             signed_auth_request
@@ -66,17 +66,17 @@ module SamlIdp
         end
 
         let(:document) { XMLSecurity::SignedDocument.new(raw_xml) }
-        let(:no_namespace_enabled) { true }
-        let(:options) { { no_namespace_enabled: } }
+        let(:digest_method_fix_enabled) { true }
+        let(:options) { { digest_method_fix_enabled: } }
 
-        context 'no_namespace_enabled is set to true' do
+        context 'digest_method_fix_enabled is set to true' do
           it 'validates the doc successfully' do
             expect(document.validate_doc(base64cert, true, options)).to be true
           end
         end
 
-        context 'no_namespace_enabled is set to false' do
-          let(:no_namespace_enabled) { false }
+        context 'digest_method_fix_enabled is set to false' do
+          let(:digest_method_fix_enabled) { false }
 
           it 'validates the doc successfully' do
             expect(document.validate_doc(base64cert, true, options)).to be true
@@ -121,9 +121,6 @@ module SamlIdp
       end
 
       describe '#digest_method_algorithm' do
-        let(:document) do
-          XMLSecurity::SignedDocument.new(fixture(:no_ds_namespace, false))
-        end
         let(:sig_namespace_hash) { { 'ds' => 'http://www.w3.org/2000/09/xmldsig#' } }
 
         let(:el) do
@@ -142,21 +139,124 @@ module SamlIdp
           REXML::XPath.first(sig_element, '//ds:Reference', sig_namespace_hash)
         end
 
-        it 'returns the value in the DigestMethod node' do
-          expect(document.send(
-            :digest_method_algorithm,
-            ref,
-            sig_namespace_hash
-          )).to eq OpenSSL::Digest::SHA256
+        context 'digest_method_fix_enabled is true' do
+          let(:digest_method_fix_enabled) { true }
+
+          context 'document does not have ds namespace for Signature elements' do
+            let(:document) do
+              XMLSecurity::SignedDocument.new(fixture(:no_ds_namespace, false))
+            end
+
+            it 'returns the value in the DigestMethod node' do
+              expect(document.send(
+                       :digest_method_algorithm,
+                       ref,
+                       sig_namespace_hash,
+                       digest_method_fix_enabled
+                     )).to eq OpenSSL::Digest::SHA256
+            end
+
+            describe 'when the namespace hash is not defined' do
+              it 'returns the default algorithm type' do
+                expect(document.send(
+                         :digest_method_algorithm,
+                         ref,
+                         {},
+                         digest_method_fix_enabled
+                       )).to eq OpenSSL::Digest::SHA1
+              end
+            end
+          end
+
+          context 'document does have ds namespace for Signature elements' do
+            let(:raw_xml) do
+              SamlIdp::Request.from_deflated_request(
+                signed_auth_request
+              ).raw_xml
+            end
+
+            let(:document) { XMLSecurity::SignedDocument.new(raw_xml) }
+
+            it 'returns the value in the DigestMethod node' do
+              expect(document.send(
+                       :digest_method_algorithm,
+                       ref,
+                       sig_namespace_hash,
+                       digest_method_fix_enabled
+                     )).to eq OpenSSL::Digest::SHA256
+            end
+
+            describe 'when the namespace hash is not defined' do
+              it 'returns the default algorithm type' do
+                expect(document.send(
+                         :digest_method_algorithm,
+                         ref,
+                         {},
+                         digest_method_fix_enabled
+                       )).to eq OpenSSL::Digest::SHA1
+              end
+            end
+          end
         end
 
-        describe 'when the namespace hash is not defined' do
-          it 'returns the default algorithm type' do
-            expect(document.send(
-              :digest_method_algorithm,
-              ref,
-              {}
-            )).to eq OpenSSL::Digest::SHA1
+        context 'digest_method_fix_enabled is false' do
+          let(:digest_method_fix_enabled) { false }
+
+          context 'document does not have ds namespace for Signature elements' do
+            let(:document) do
+              XMLSecurity::SignedDocument.new(fixture(:no_ds_namespace, false))
+            end
+
+            it 'returns the default algorithm type' do
+              expect(document.send(
+                       :digest_method_algorithm,
+                       ref,
+                       sig_namespace_hash,
+                       digest_method_fix_enabled
+                     )).to eq OpenSSL::Digest::SHA1
+            end
+
+            describe 'when the namespace hash is not defined' do
+              it 'returns the default algorithm type' do
+                expect(document.send(
+                         :digest_method_algorithm,
+                         ref,
+                         {},
+                         digest_method_fix_enabled
+                       )).to eq OpenSSL::Digest::SHA1
+              end
+            end
+          end
+
+          context 'document does have ds namespace for Signature elements' do
+            let(:raw_xml) do
+              SamlIdp::Request.from_deflated_request(
+                signed_auth_request
+              ).raw_xml
+            end
+
+            let(:document) { XMLSecurity::SignedDocument.new(raw_xml) }
+
+            it 'returns the value in the DigestMethod node' do
+              expect(document.send(
+                       :digest_method_algorithm,
+                       ref,
+                       sig_namespace_hash,
+                       digest_method_fix_enabled
+                     )).to eq OpenSSL::Digest::SHA256
+            end
+
+            describe 'when the namespace hash is not defined' do
+              it 'returns the value in the DigestMethod node' do
+                # in this scenario, the undefined namespace hash is ignored
+                expect(document.send(
+                         :digest_method_algorithm,
+                         ref,
+                         {},
+                         digest_method_fix_enabled
+                       )).to eq OpenSSL::Digest::SHA256
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
There is a potential scenario where a partner has:

- updated their signing certificate
- the certificate is correct but not using the `ds` namespace
- because of that, the IdP is unable to correctly match the signing certificate
- the IdP response is encrypted with an older certificate (which is determined by `service_provider.certs.first`)
- the partner never updated their application code to decrypt the response with the signing certificate

This change introduces a conditional so we can continue using the old code path while allowing us to compare and log the `matching_cert` results [here](https://github.com/18F/identity-idp/blob/1e24342abce8463018db095911a7e26c5c9e802d/app/controllers/saml_idp_controller.rb#L133)