### PR TITLE
Return errors for logging

### DIFF
--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -86,6 +86,12 @@ module Saml
         Namespaces::SIGNATURE
       end
 
+      def gather_errors(fingerprint, options = {})
+        signed_document.validate(fingerprint, false, options)
+      rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError => e
+        { cert: options[:cert].serial.to_s, error_code: e.error_code }
+      end
+
       def to_xml
         super(
           save_with: Nokogiri::XML::Node::SaveOptions::AS_XML | Nokogiri::XML::Node::SaveOptions::NO_DECLARATION

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -170,10 +170,27 @@ module SamlIdp
 
       Array(service_provider.certs).find do |cert|
         document.valid_signature?(
-          OpenSSL::Digest::SHA256.new(cert.to_der).hexdigest,
+          fingerprint(cert),
           options.merge(cert:, digest_method_fix_enabled: true)
         )
       end
+    end
+
+    def cert_errors
+      return nil unless signed?
+      return nil if matching_cert.present?
+      return [{ cert: nil, error_code: :no_registered_certs }] if service_provider.certs.blank?
+
+      Array(service_provider.certs).map do |cert|
+        document.gather_errors(
+          fingerprint(cert),
+          options.merge(cert:, digest_method_fix_enabled: true)
+        )
+      end
+    end
+
+    def fingerprint(cert)
+      OpenSSL::Digest::SHA256.new(cert.to_der).hexdigest
     end
 
     def signed?
@@ -191,7 +208,7 @@ module SamlIdp
     end
 
     def service_provider
-      return unless issuer.present?
+      return if issuer.blank?
 
       @_service_provider ||= ServiceProvider.new((service_provider_finder[issuer] || {}).merge(identifier: issuer))
     end

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -178,7 +178,12 @@ module SamlIdp
 
     def cert_errors
       return nil unless signed?
-      return nil if matching_cert.present?
+      begin
+        return nil if matching_cert.present?
+      rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError => e
+        return [{ cert: nil, error_code: e.error_code }]
+      end
+
       return [{ cert: nil, error_code: :no_registered_certs }] if service_provider.certs.blank?
 
       Array(service_provider.certs).map do |cert|

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.21.3-18f'.freeze
+  VERSION = '0.21.4-18f'.freeze
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -32,7 +32,15 @@ require 'digest/sha2'
 module SamlIdp
   module XMLSecurity
     class SignedDocument < REXML::Document
-      ValidationError = Class.new(StandardError)
+      class ValidationError < StandardError
+        attr_reader :error_code
+
+        def initialize(msg = nil, error_code = nil)
+          @error_code = error_code
+          super(msg)
+        end
+      end
+
       C14N = 'http://www.w3.org/2001/10/xml-exc-c14n#'
       DSIG = 'http://www.w3.org/2000/09/xmldsig#'
 
@@ -60,7 +68,8 @@ module SamlIdp
         plain_idp_cert_fingerprint = idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/, '').downcase
 
         if fingerprint != plain_idp_cert_fingerprint && sha1_fingerprint != plain_idp_cert_fingerprint
-          return soft ? false : (raise ValidationError.new('Fingerprint mismatch'))
+          return soft ? false : (raise ValidationError.new('Fingerprint mismatch',
+                                                           :fingerprint_mismatch))
         end
 
         validate_doc(base64_cert, soft, options)

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -500,7 +500,6 @@ module SamlIdp
         describe 'the service provider has no registered certs' do
           before { subject.service_provider.certs = [] }
 
-
           it 'returns a no registered cert error' do
             expect(subject.cert_errors).to eq [{cert: nil, error_code: :no_registered_certs}]
           end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -511,13 +511,78 @@ module SamlIdp
           let(:errors) { [{ cert: cert.serial.to_s, error_code: error_code }] }
 
           describe 'the cert matches the assertion cert' do
-            it 'returns the cert' do
+            it 'returns nil' do
               expect(subject.cert_errors).to be_nil
             end
           end
 
+          describe 'the embedded certificate is bad' do
+            let(:error_code) { :invalid_certificate_in_request }
+            let(:cert_text) do
+              invalid_cert.to_s.
+              gsub('-----BEGIN CERTIFICATE-----', '').
+              gsub('-----END CERTIFICATE-----', '').
+              gsub("\n", '')
+            end
+            before do
+              allow(OpenSSL::X509::Certificate).to receive(:new).with(Base64.decode64(cert_text)).and_raise OpenSSL::X509::CertificateError
+            end
+
+            let(:saml_request) do
+              make_invalid_saml_request(values: {certificate: invalid_cert.to_pem}, signed: true)
+            end
+
+            it 'returns an invalid certificate error' do
+              expect(subject.cert_errors).to eq errors
+            end
+          end
+
+          describe 'the cert element exists but is empty' do
+            let(:error_code) { :no_certificate_in_request }
+            let(:errors) { [{ cert: nil, error_code: error_code }] }
+            let(:blank_cert_element_req) do
+              <<-XML.gsub(/^[\s]+|[\s]+\n/, '')
+                <?xml version="1.0"?>
+                <samlp:LogoutRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Destination="http://www.example.com/api/saml/logout2024" ID="_223d186c-35a0-4d1f-b81a-c473ad496415" IssueInstant="2024-01-11T18:22:03Z" Version="2.0">
+                  <saml:Issuer>http://localhost:3000</saml:Issuer>
+                  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                    <ds:SignedInfo>
+                      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                      <ds:Reference URI="#_223d186c-35a0-4d1f-b81a-c473ad496415">
+                        <ds:Transforms>
+                          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                            <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="#default samlp saml ds xs xsi md"/>
+                          </ds:Transform>
+                        </ds:Transforms>
+                        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                        <ds:DigestValue>2Nb3RLbiFHn0cyn+7JA7hWbbK1NvFMVGa4MYTb3Q91I=</ds:DigestValue>
+                      </ds:Reference>
+                    </ds:SignedInfo>
+                    <ds:SignatureValue>UmsRcaWkHXrUnBMfOQBC2DIQk1rkQqMc5oucz6FAjulq0ZX7qT+zUbSZ7K/us+lzcL1hrgHXi2wxjKSRiisWrJNSmbIGGZIa4+U8wIMhkuY5vZVKgxRc2aP88i/lWwURMI183ifAzCwpq5Y4yaJ6pH+jbgYOtmOhcXh1OwrI+QqR7QSglyUJ55WO+BCR07Hf8A7DSA/Wgp9xH+DUw1EnwbDdzoi7TFqaHY8S4SWIcc26DHsq88mjsmsxAFRQ+4t6nadOnrrFnJWKJeiFlD8MxcQuBiuYBetKRLIPxyXKFxjEn7EkJ5zDkkrBWyUT4VT/JnthUlD825D+v81ZXIX3Tg==</ds:SignatureValue>
+                    <ds:KeyInfo>
+                      <ds:X509Data>
+                        <ds:X509Certificate>
+                        </ds:X509Certificate>
+                      </ds:X509Data>
+                    </ds:KeyInfo>
+                  </ds:Signature>
+                  <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">_13ae90d1-2f9b-4ed5-b84d-3722ea42e386</saml:NameID>
+                </samlp:LogoutRequest>
+              XML
+            end
+            let(:saml_request) do
+              Base64.encode64(Zlib::Deflate.deflate(blank_cert_element_req, 9)[2..-5])
+            end
+
+            it 'returns a no certificate in request error' do
+              expect(subject.cert_errors).to eq errors
+            end
+          end
+
           describe 'the cert does not match the assertion cert' do
-            describe 'mismatched digest' do
+            describe 'returns a fingerprint mismatch error' do
               let(:cert) { OpenSSL::X509::Certificate.new(cloudhsm_idp_x509_cert) }
               let(:error_code) { :fingerprint_mismatch }
 
@@ -528,13 +593,27 @@ module SamlIdp
           end
         end
 
-        xdescribe 'multiple certs' do
+        describe 'sp has multiple certs' do
           let(:not_matching_cert) { OpenSSL::X509::Certificate.new(cloudhsm_idp_x509_cert) }
 
           before { subject.service_provider.certs = [not_matching_cert, invalid_cert, cert] }
+          describe 'there is a matching cert' do
+            it 'returns nil' do
+              expect(subject.cert_errors).to be_nil
+            end
+          end
 
-          it 'returns the matching cert' do
-            expect(subject.matching_cert).to eq cert
+          describe 'there are no matching certs' do
+            before { subject.service_provider.certs = [not_matching_cert, invalid_cert] }
+
+            it 'returns multiple errors' do
+              expected_errors = [
+                { cert: not_matching_cert.serial.to_s, error_code: :fingerprint_mismatch },
+                { cert: invalid_cert.serial.to_s, error_code: :fingerprint_mismatch },
+              ]
+              expect(subject.cert_errors).to eq expected_errors
+            end
+
           end
         end
       end


### PR DESCRIPTION
We would like to better understand what certificate validation errors are preventing partners from having valid signatures. 
This change creates a method to collect certificate errors so that we can surface them for logging. 
Note: it's not quite done, as I'd like to try to write some tests for the `gather_errors` method but I wanted to get this pushed and in front of others as soon as possible.

Things to keep in mind:

- Since an integration can have multiple registered certificates, it is necessary to loop through all of them to return error details. (Since we can't find a "matching" certificate, we don't know which one is the correct one to return errors for)
- I tested some of the error cases. The behavior is consistent across errors, so it felt less important to test every one, especially as some are very difficult to set up (and some are basically impossible to actually happen from the Request) class, but I can try to figure out how to stub or set up to test the other cases if it feels important to others.

Open questions I would love feedback on:
- I've been thinking a little bit about whether it's worth it to create a `Certificate` class to handle details about individual certificates, but was curious if others had thoughts about that approach before trying it.
- What other fields would be helpful to return for logging? I was thinking maybe the expiration date of the serial, as an expired certificate is less likely to be the one with the issue.