### PR TITLE
Replace REXML with Nokogiri for consistency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.21.5.pre.18f)
+    saml_idp (0.21.6.pre.18f)
       activesupport
       builder
       faraday

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,6 @@ DEPENDENCIES
   pry-byebug
   rails (~> 7.1)
   rake
-  rexml
   rspec
   rubocop (= 1.62.0)
   rubocop-rails (= 2.9)

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.21.5-18f'.freeze
+  VERSION = '0.21.6-18f'.freeze
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -46,7 +46,7 @@ module SamlIdp
       attr_accessor :document
 
       def initialize(response)
-        @document = Nokogiri.parse(response)
+        @document = Nokogiri.XML(response)
       end
 
       def validate(idp_cert_fingerprint, soft = true, options = {})

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -180,13 +180,13 @@ module SamlIdp
 
         sig_element = document.at_xpath('//*:Signature')
         sig_namespace_hash = sig_element.at_xpath('//*:SignedInfo')&.namespaces
-        noko_signed_info_element = sig_element.at_xpath('./*:SignedInfo')
+        signed_info_element = sig_element.at_xpath('./*:SignedInfo')
 
         canon_algorithm = canon_algorithm(
           sig_element.at_xpath('//*:CanonicalizationMethod')
         )
 
-        canon_string = noko_signed_info_element.canonicalize(canon_algorithm)
+        canon_string = signed_info_element.canonicalize(canon_algorithm)
         # check digests
         sig_element.xpath('//*:Reference').each do |ref|
           uri = ref.attribute('URI').value
@@ -251,13 +251,6 @@ module SamlIdp
 
       def digests_match?(hash, digest_value)
         hash == digest_value
-      end
-
-      def extract_signed_element_id
-        reference_element = document.at_xpath('//*:Signature/*:SignedInfo/*:Reference')
-        return if reference_element.nil?
-
-        @signed_element_id = reference_element.attribute('URI').value[1..-1]
       end
 
       def canon_algorithm(element)

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency('rails', '~> 7.1')
   s.add_development_dependency 'rake'
-  s.add_development_dependency('rexml')
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '1.62.0'
   s.add_development_dependency 'rubocop-rails', '2.9'

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -91,10 +91,9 @@ describe SamlIdp::Controller do
     it 'signs a SAML Response if requested' do
       saml_response_encoded = encode_response(principal, signed_response_message: true)
       saml_response_text = Base64.decode64(saml_response_encoded)
-      saml_response = REXML::Document.new(saml_response_text)
-      response_id = REXML::XPath.match(saml_response, '//samlp:Response').first.attributes['ID']
-      signature_ref = REXML::XPath.match(saml_response,
-                                         '//ds:Reference').first.attributes['URI'][1..-1]
+      saml_response = Nokogiri.parse(saml_response_text)
+      response_id = saml_response.at_xpath('//*:Response').attributes['ID'].value
+      signature_ref = saml_response.at_xpath('//*:Reference').attributes['URI'].value[1..-1]
 
       expect(signature_ref).to eq response_id
     end

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -91,7 +91,7 @@ describe SamlIdp::Controller do
     it 'signs a SAML Response if requested' do
       saml_response_encoded = encode_response(principal, signed_response_message: true)
       saml_response_text = Base64.decode64(saml_response_encoded)
-      saml_response = Nokogiri.parse(saml_response_text)
+      saml_response = Nokogiri.XML(saml_response_text)
       response_id = saml_response.at_xpath('//*:Response').attributes['ID'].value
       signature_ref = saml_response.at_xpath('//*:Reference').attributes['URI'].value[1..-1]
 

--- a/spec/lib/saml_idp/logout_response_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_response_builder_spec.rb
@@ -39,10 +39,8 @@ module SamlIdp
     end
 
     it 'includes the response_id in the signature' do
-      signed = subject.signed
-      doc = REXML::Document.new signed
-      signature = REXML::XPath.first(doc, '//ds:Signature',
-                                     { 'ds' => SamlIdp::XMLSecurity::SignedDocument::DSIG })
+      doc = Nokogiri.parse subject.signed
+      signature = doc.at_xpath('//*:Signature')
       expect(signature.to_s).to include(response_id)
     end
   end

--- a/spec/lib/saml_idp/logout_response_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_response_builder_spec.rb
@@ -39,7 +39,7 @@ module SamlIdp
     end
 
     it 'includes the response_id in the signature' do
-      doc = Nokogiri.parse subject.signed
+      doc = Nokogiri.XML subject.signed
       signature = doc.at_xpath('//*:Signature')
       expect(signature.to_s).to include(response_id)
     end

--- a/spec/support/responses/no_ds_namespace_request.xml
+++ b/spec/support/responses/no_ds_namespace_request.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <samlp:AuthnRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_2b07dcbe-544a-4443-8199-fa45d91c1699" Version="2.0" IssueInstant="2024-05-28T16:49:52.266403Z" Destination="https://secure.login.gov/api/saml/auth2024" ForceAuthn="false" IsPassive="false" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://pbgccommercialazureprod.b2clogin.com/pbgccommercialazureprod.onmicrosoft.com/B2C_1A_TrustFrameworkBase/samlp/sso/assertionconsumer">
   <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://login.example.com/issuer</Issuer>
-  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+  <Signature>
     <SignedInfo>
       <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
       <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -94,11 +94,4 @@ module SamlRequestMacros
 
     settings
   end
-
-  def print_pretty_xml(xml_string)
-    doc = REXML::Document.new xml_string
-    outbuf = ''
-    doc.write(outbuf, 1)
-    puts outbuf
-  end
 end

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -4,13 +4,14 @@ require 'xml_security'
 module SamlIdp
   describe 'XmlSecurity::SignedDocument' do
     let(:xml_string) { fixture('valid_response_sha1.xml', false) }
+    let(:ds_namespace) { { 'ds' => 'http://www.w3.org/2000/09/xmldsig#' } }
 
     subject do
       XMLSecurity::SignedDocument.new(xml_string)
     end
 
     let(:base64cert) do
-      subject.document.at_xpath('//*:X509Certificate').text
+      subject.document.at_xpath('//ds:X509Certificate', ds_namespace).text
     end
 
     describe '#validate_doc' do
@@ -137,14 +138,13 @@ module SamlIdp
 
       describe '#digest_method_algorithm' do
         let(:xml_string) { fixture(:no_ds_namespace_request, false) }
-        let(:sig_namespace_hash) { { 'ds' => 'http://www.w3.org/2000/09/xmldsig#' } }
 
         let(:sig_element) do
-          subject.document.at_xpath('//*:Signature')
+          subject.document.at_xpath('//ds:Signature | //Signature', ds_namespace)
         end
 
         let(:ref) do
-          sig_element.at_xpath('//*:Reference')
+          sig_element.at_xpath('//ds:Reference | //Reference', ds_namespace)
         end
 
         context 'digest_method_fix_enabled is true' do
@@ -161,7 +161,7 @@ module SamlIdp
 
             describe 'when the DigestMethod node does not exist' do
               before do
-                ref.at_xpath('//*:DigestMethod').remove
+                ref.at_xpath('//ds:DigestMethod | //DigestMethod', ds_namespace).remove
               end
 
               it 'returns the default algorithm type' do
@@ -191,7 +191,7 @@ module SamlIdp
 
             describe 'when the DigestMethod node does not exist' do
               before do
-                ref.at_xpath('//*:DigestMethod').remove
+                ref.at_xpath('//ds:DigestMethod | //DigestMethod', ds_namespace).remove
               end
 
               it 'returns the default algorithm type' do

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -2,24 +2,26 @@ require 'spec_helper'
 require 'xml_security'
 
 module SamlIdp
-  describe XMLSecurity, :security do
-    let(:document) { XMLSecurity::SignedDocument.new(Base64.decode64(valid_response_document)) }
+  describe 'XmlSecurity::SignedDocument' do
+    let(:xml_string) { fixture('valid_response_sha1.xml', false) }
 
-    let(:document_with_invalid_certificate) do
-      XMLSecurity::SignedDocument.new(Base64.decode64(invalid_x509_cert_response))
+    subject do
+      XMLSecurity::SignedDocument.new(xml_string)
     end
 
-    let(:base64cert) { document.elements['//ds:X509Certificate'].text }
+    let(:base64cert) do
+      subject.document.at_xpath('//*:X509Certificate').text
+    end
 
     describe '#validate_doc' do
       describe 'when softly validating' do
         it 'does not throw NS related exceptions' do
-          expect(document.validate_doc(base64cert, true)).to be_falsey
+          expect(subject.validate_doc(base64cert, true)).to be_falsey
         end
 
         context 'multiple validations' do
           it 'does not raise an error' do
-            expect { 2.times { document.validate_doc(base64cert, true) } }.not_to raise_error
+            expect { 2.times { subject.validate_doc(base64cert, true) } }.not_to raise_error
           end
         end
       end
@@ -27,51 +29,53 @@ module SamlIdp
       describe 'when validating not softly' do
         it 'throws NS related exceptions' do
           expect do
-            document.validate_doc(base64cert,
+            subject.validate_doc(base64cert,
                                   false)
           end.to raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError)
         end
 
         it 'raises Fingerprint mismatch' do
-          expect { document.validate('no:fi:ng:er:pr:in:t', false) }.to(
+          expect { subject.validate('no:fi:ng:er:pr:in:t', false) }.to(
             raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError,
                         'Fingerprint mismatch')
           )
         end
 
         it 'raises Digest mismatch' do
-          expect { document.validate_doc(base64cert, false) }.to(
+          expect { subject.validate_doc(base64cert, false) }.to(
             raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError, 'Digest mismatch')
           )
         end
 
-        it 'raises Key validation error' do
-          response = Base64.decode64(valid_response_document)
-          response.sub!('<ds:DigestValue>pJQ7MS/ek4KRRWGmv/H43ReHYMs=</ds:DigestValue>',
-                        '<ds:DigestValue>b9xsAXLsynugg3Wc1CI3kpWku+0=</ds:DigestValue>')
-          document = XMLSecurity::SignedDocument.new(response)
-          base64cert = document.elements['//ds:X509Certificate'].text
-          expect { document.validate_doc(base64cert, false) }.to(
-            raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError,
-                        'Key validation error')
-          )
+        context 'Key validation error' do
+          let(:xml_string) do
+            xml = fixture('valid_response_sha1.xml', false)
+            xml.sub!('<ds:DigestValue>pJQ7MS/ek4KRRWGmv/H43ReHYMs=</ds:DigestValue>',
+              '<ds:DigestValue>b9xsAXLsynugg3Wc1CI3kpWku+0=</ds:DigestValue>')
+          end
+
+          it 'raises Key validation error' do
+            expect { subject.validate_doc(base64cert, false) }.to(
+              raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError,
+                          'Key validation error')
+            )
+          end
         end
       end
 
       describe 'options[:digest_method_fix_enabled]' do
-        let(:raw_xml) do
+        let(:xml_string) do
           SamlIdp::Request.from_deflated_request(
             signed_auth_request
           ).raw_xml
         end
 
-        let(:document) { XMLSecurity::SignedDocument.new(raw_xml) }
         let(:digest_method_fix_enabled) { true }
         let(:options) { { digest_method_fix_enabled: } }
 
         context 'digest_method_fix_enabled is set to true' do
           it 'validates the doc successfully' do
-            expect(document.validate_doc(base64cert, true, options)).to be true
+            expect(subject.validate_doc(base64cert, true, options)).to be true
           end
         end
 
@@ -79,7 +83,7 @@ module SamlIdp
           let(:digest_method_fix_enabled) { false }
 
           it 'validates the doc successfully' do
-            expect(document.validate_doc(base64cert, true, options)).to be true
+            expect(subject.validate_doc(base64cert, true, options)).to be true
           end
         end
       end
@@ -87,48 +91,56 @@ module SamlIdp
 
     describe '#validate' do
       describe 'errors' do
-        it 'raises invalid certificates when the document certificate is invalid' do
-          expect { document_with_invalid_certificate.validate('no:fi:ng:er:pr:in:t', false) }.to(
-            raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError,
-                        'Invalid certificate')
-          )
+        context 'invalid document certificate' do
+          let(:xml_string) { fixture('invalid_x509_cert_response.xml', false) }
+
+          it 'raises invalid certificates when the document certificate is invalid' do
+            expect { subject.validate('no:fi:ng:er:pr:in:t', false) }.to(
+              raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError,
+                          'Invalid certificate')
+            )
+          end
         end
 
-        it 'raises validation error when the X509Certificate is missing' do
-          response = Base64.decode64(valid_response_document)
-          response.sub!(%r{<ds:X509Certificate>.*</ds:X509Certificate>}, '')
-          document = XMLSecurity::SignedDocument.new(response)
-          expect { document.validate('a fingerprint', false) }.to(
-            raise_error(
-              SamlIdp::XMLSecurity::SignedDocument::ValidationError,
-              'Certificate element missing in response (ds:X509Certificate) and not provided in options[:cert]'
+        context 'x509Certicate is missing' do
+          let(:xml_string) do
+            xml = fixture('valid_response_sha1.xml', false)
+            xml.sub!(%r{<ds:X509Certificate>.*</ds:X509Certificate>}, '')
+          end
+
+          it 'raises validation error when the X509Certificate is missing' do
+            expect { subject.validate('a fingerprint', false) }.to(
+              raise_error(
+                SamlIdp::XMLSecurity::SignedDocument::ValidationError,
+                'Certificate element missing in response (ds:X509Certificate) and not provided in options[:cert]'
+              )
             )
-          )
+          end
         end
 
-        it 'raises a validation error when find_base64_cert returns nil' do
-          response = Base64.decode64(valid_response_document)
-          response.sub!(%r{<ds:X509Certificate>.*</ds:X509Certificate>}, '<ds:X509Certificate></ds:X509Certificate>')
-          document = XMLSecurity::SignedDocument.new(response)
+        context 'find_base_64 returns nil' do
+          let(:xml_string) do
+            xml = fixture('valid_response_sha1.xml', false)
+            xml.sub!(%r{<ds:X509Certificate>.*</ds:X509Certificate>}, '<ds:X509Certificate></ds:X509Certificate>')
+          end
 
-          expect { document.validate('a fingerprint', false) }.to(
-            raise_error(
-              SamlIdp::XMLSecurity::SignedDocument::ValidationError,
-              'Certificate element present in response (ds:X509Certificate) but evaluating to nil'
+          it 'raises a validation error when find_base64_cert returns nil' do
+            expect { subject.validate('a fingerprint', false) }.to(
+              raise_error(
+                SamlIdp::XMLSecurity::SignedDocument::ValidationError,
+                'Certificate element present in response (ds:X509Certificate) but evaluating to nil'
+              )
             )
-          )
+          end
         end
       end
 
       describe '#digest_method_algorithm' do
-        let(:document) do
-          XMLSecurity::SignedDocument.new(fixture(:no_ds_namespace_request, false))
-        end
+        let(:xml_string) { fixture(:no_ds_namespace_request, false) }
         let(:sig_namespace_hash) { { 'ds' => 'http://www.w3.org/2000/09/xmldsig#' } }
-        let(:noko_document) { Nokogiri.parse(document.to_s) }
 
         let(:sig_element) do
-          noko_document.at_xpath('//*:Signature')
+          subject.document.at_xpath('//*:Signature')
         end
 
         let(:ref) do
@@ -140,7 +152,7 @@ module SamlIdp
 
           context 'document does not have ds namespace for Signature elements' do
             it 'returns the value in the DigestMethod node' do
-              expect(document.send(
+              expect(subject.send(
                        :digest_method_algorithm,
                        ref,
                        digest_method_fix_enabled
@@ -153,7 +165,7 @@ module SamlIdp
               end
 
               it 'returns the default algorithm type' do
-                expect(document.send(
+                expect(subject.send(
                          :digest_method_algorithm,
                          ref,
                          digest_method_fix_enabled
@@ -163,16 +175,14 @@ module SamlIdp
           end
 
           context 'document does have ds namespace for Signature elements' do
-            let(:raw_xml) do
+            let(:xml_string) do
               SamlIdp::Request.from_deflated_request(
                 signed_auth_request
               ).raw_xml
             end
 
-            let(:document) { XMLSecurity::SignedDocument.new(raw_xml) }
-
             it 'returns the value in the DigestMethod node' do
-              expect(document.send(
+              expect(subject.send(
                        :digest_method_algorithm,
                        ref,
                        digest_method_fix_enabled
@@ -185,7 +195,7 @@ module SamlIdp
               end
 
               it 'returns the default algorithm type' do
-                expect(document.send(
+                expect(subject.send(
                          :digest_method_algorithm,
                          ref,
                          digest_method_fix_enabled
@@ -199,12 +209,10 @@ module SamlIdp
           let(:digest_method_fix_enabled) { false }
 
           context 'document does not have ds namespace for Signature elements' do
-            let(:document) do
-              XMLSecurity::SignedDocument.new(fixture(:no_ds_namespace_request, false))
-            end
+            let(:xml_string) { fixture(:no_ds_namespace_request, false) }
 
             it 'returns the default algorithm type' do
-              expect(document.send(
+              expect(subject.send(
                        :digest_method_algorithm,
                        ref,
                        digest_method_fix_enabled
@@ -213,7 +221,7 @@ module SamlIdp
 
             describe 'when the namespace hash is not defined' do
               it 'returns the default algorithm type' do
-                expect(document.send(
+                expect(subject.send(
                          :digest_method_algorithm,
                          ref,
                          digest_method_fix_enabled
@@ -223,16 +231,14 @@ module SamlIdp
           end
 
           context 'document does have ds namespace for Signature elements' do
-            let(:raw_xml) do
+            let(:xml_string) do
               SamlIdp::Request.from_deflated_request(
                 signed_auth_request
               ).raw_xml
             end
 
-            let(:document) { XMLSecurity::SignedDocument.new(raw_xml) }
-
             it 'returns the value in the DigestMethod node' do
-              expect(document.send(
+              expect(subject.send(
                        :digest_method_algorithm,
                        ref,
                        digest_method_fix_enabled
@@ -242,7 +248,7 @@ module SamlIdp
             describe 'when the namespace hash is not defined' do
               it 'returns the value in the DigestMethod node' do
                 # in this scenario, the undefined namespace hash is ignored
-                expect(document.send(
+                expect(subject.send(
                          :digest_method_algorithm,
                          ref,
                          digest_method_fix_enabled
@@ -254,55 +260,71 @@ module SamlIdp
       end
 
       describe 'Algorithms' do
-        it 'validate using SHA1' do
-          document = XMLSecurity::SignedDocument.new(fixture(:adfs_response_sha1, false))
-          expect(document.validate('F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72')).to be_truthy
+        context 'SHA1' do
+          let(:xml_string) { fixture(:adfs_response_sha1, false) }
+          it 'validate using SHA1' do
+            expect(subject.validate('F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72')).to be_truthy
+          end
         end
 
-        it 'validate using SHA256' do
-          document = XMLSecurity::SignedDocument.new(fixture(:adfs_response_sha256, false))
-          expect(document.validate('28:74:9B:E8:1F:E8:10:9C:A8:7C:A9:C3:E3:C5:01:6C:92:1C:B4:BA')).to be_truthy
+        context 'SHA256' do
+          let(:xml_string) { fixture(:adfs_response_sha256, false) }
+          it 'validate using SHA256' do
+            expect(subject.validate('28:74:9B:E8:1F:E8:10:9C:A8:7C:A9:C3:E3:C5:01:6C:92:1C:B4:BA')).to be_truthy
+          end
         end
 
-        it 'validate using SHA384' do
-          document = XMLSecurity::SignedDocument.new(fixture(:adfs_response_sha384, false))
-          expect(document.validate('F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72')).to be_truthy
+        context 'SHA384' do
+          let(:xml_string) { fixture(:adfs_response_sha384, false) }
+
+          it 'validate using SHA384' do
+            expect(subject.validate('F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72')).to be_truthy
+          end
         end
 
-        it 'validate using SHA512' do
-          document = XMLSecurity::SignedDocument.new(fixture(:adfs_response_sha512, false))
-          expect(document.validate('F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72')).to be_truthy
+        context 'SHA512' do
+          let(:xml_string) { fixture(:adfs_response_sha512, false) }
+
+          it 'validate using SHA512' do
+            expect(subject.validate('F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72')).to be_truthy
+          end
         end
       end
     end
-  end
 
-  describe 'XmlSecurity::SignedDocument' do
     describe '#extract_inclusive_namespaces' do
-      it 'support explicit namespace resolution for exclusive canonicalization' do
-        response = fixture(:open_saml_response, false)
-        document = XMLSecurity::SignedDocument.new(response)
-        inclusive_namespaces = document.send(:extract_inclusive_namespaces)
+      context 'explicit namespace resolution' do
+        let(:xml_string) { fixture(:open_saml_response, false )}
 
-        expect(inclusive_namespaces).to eq(%w[xs])
+        it 'supports explicit namespace resolution for exclusive canonicalization' do
+          inclusive_namespaces = subject.send(:extract_inclusive_namespaces)
+
+          expect(inclusive_namespaces).to eq(%w[xs])
+        end
       end
 
-      it 'support implicit namespace resolution for exclusive canonicalization' do
-        response = fixture(:no_signature_ns, false)
-        document = XMLSecurity::SignedDocument.new(response)
-        inclusive_namespaces = document.send(:extract_inclusive_namespaces)
+      context 'implicit namespace resolution' do
+        let(:xml_string) { fixture(:no_signature_ns, false )}
 
-        expect(inclusive_namespaces).to eq(%w[#default saml ds xs xsi])
+        it 'supports implicit namespace resolution for exclusive canonicalization' do
+          inclusive_namespaces = subject.send(:extract_inclusive_namespaces)
+
+          expect(inclusive_namespaces).to eq(%w[#default saml ds xs xsi])
+        end
       end
 
-      it 'return an empty list when inclusive namespace element is missing' do
-        response = fixture(:no_signature_ns, false)
-        response.slice! %r{<InclusiveNamespaces xmlns="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="#default saml ds xs xsi"/>}
+      context 'inclusive namespace element is missing' do
+        let(:xml_string) do
+          xml = fixture(:no_signature_ns, false)
+          xml.slice! %r{<InclusiveNamespaces xmlns="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="#default saml ds xs xsi"/>}
+          xml
+        end
 
-        document = XMLSecurity::SignedDocument.new(response)
-        inclusive_namespaces = document.send(:extract_inclusive_namespaces)
+        it 'return an empty list when inclusive namespace element is missing' do
+          inclusive_namespaces = subject.send(:extract_inclusive_namespaces)
 
-        expect(inclusive_namespaces).to be_empty
+          expect(inclusive_namespaces).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
As I've been trying to clean up parts of this code, I noticed a bunch of repetition around XML processing because the XMLSecurity class was using both REXML and Nokogiri for processing. I decided to take a stab at choosing one to make it clearer and more consistent, so that we can focus on understanding the SAML processing rather than how the XML parser is working.

The tests are all passing, which is a great sign, but I'd love some feedback about whether this seems like a positive change, or if there are more tests I can/should write to create more confidence in the change.