### PR TITLE
Use request matching cert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ GEM
     rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
-    ruby-saml (1.16.0)
+    ruby-saml (1.17.0)
       nokogiri (>= 1.13.10)
       rexml
     simplecov (0.22.0)
@@ -312,7 +312,7 @@ DEPENDENCIES
   rubocop (= 1.62.0)
   rubocop-rails (= 2.9)
   rubocop-rspec
-  ruby-saml (~> 1.16.0)
+  ruby-saml (~> 1.17.0)
   saml_idp!
   simplecov (~> 0.22.0)
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.22.0.pre.18f)
+    saml_idp (0.23.0.pre.18f)
       activesupport
       builder
       faraday

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -190,7 +190,10 @@ module SamlIdp
     def valid_signature?
       # Force signatures for logout requests because there is no other
       # protection against a cross-site DoS.
-      service_provider.valid_signature?(document, logout_request?, options)
+      service_provider.valid_signature?(
+        matching_cert,
+        logout_request?
+      )
     end
 
     def service_provider?

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -20,13 +20,9 @@ module SamlIdp
       attributes.present?
     end
 
-    def valid_signature?(doc, require_signature = false, options = {})
-      @matching_cert = Array(certs).find do |cert|
-        doc.valid_signature?(fingerprint_cert(cert), options.merge(cert:))
-      end
-
+    def valid_signature?(matching_cert = nil, require_signature = false)
       if require_signature || should_validate_signature?
-        !!@matching_cert
+        !!matching_cert
       else
         true
       end

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -14,8 +14,6 @@ module SamlIdp
 
     delegate :config, to: :SamlIdp
 
-    attr_reader :matching_cert
-
     def valid?
       attributes.present?
     end

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -22,7 +22,7 @@ module SamlIdp
 
     def valid_signature?(matching_cert = nil, require_signature = false)
       if require_signature || should_validate_signature?
-        !!matching_cert
+        matching_cert.present?
       else
         true
       end

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.22.0-18f'.freeze
+  VERSION = '0.23.0-18f'.freeze
 end

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '1.62.0'
   s.add_development_dependency 'rubocop-rails', '2.9'
   s.add_development_dependency 'rubocop-rspec'
-  s.add_development_dependency 'ruby-saml', '~> 1.16.0'
+  s.add_development_dependency 'ruby-saml', '~> 1.17.0'
   s.add_development_dependency 'simplecov', '~> 0.22.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency('timecop')


### PR DESCRIPTION
Link to the relevant ticket:
[lg-people/Melba/backlog-fy24#2](https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/2) and
[LG-4875](https://cm-jira.usa.gov/browse/LG-4875)

This is the final piece of work to remove the `ServiceProvider` `@matching_cert` value.

This allows us to directly find the matching_cert on the request, rather than relying on a side effect of the validation method. This also allows us to greatly simplify this method, by allowing the method to focus on whether or not a signature is required, and if is, utilizing the presence of a matching certificate to determine if it is or not validly signed.

I also noted this dependabot pr https://github.com/18F/saml_idp/pull/118 and updated the ruby-saml version. 