### PR TITLE
Method to Match certs including SHA256 errors

### DIFF
--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -92,6 +92,10 @@ module Saml
         { cert: options[:cert].serial.to_s, error_code: e.error_code }
       end
 
+      def valid_sig_with_sha256?(cert, options = {})
+        signed_document.validate_with_sha256(cert, options)
+      end
+
       def to_xml
         super(
           save_with: Nokogiri::XML::Node::SaveOptions::AS_XML | Nokogiri::XML::Node::SaveOptions::NO_DECLARATION

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -157,6 +157,15 @@ module SamlIdp
       end
     end
 
+    def sha256_validation_matching_cert
+      return nil unless signed?
+
+      Array(service_provider.certs).find do |cert|
+        document.valid_sig_with_sha256?(cert, options)
+      rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
+      end
+    end
+
     def cert_errors
       return nil unless signed?
 

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.23.1-18f'.freeze
+  VERSION = '0.23.2-18f'.freeze
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -53,16 +53,13 @@ module SamlIdp
         log 'Validate the fingerprint'
         base64_cert = find_base64_cert(options)
         cert_text = Base64.decode64(base64_cert)
-        cert =
-          begin
-            OpenSSL::X509::Certificate.new(cert_text)
-          rescue OpenSSL::X509::CertificateError
-            return false if soft
-            raise ValidationError.new(
-              'Invalid certificate',
-              :invalid_certificate_in_request
-            )
-          end
+      begin
+        cert = valid_cert(cert_text)
+      rescue OpenSSL::X509::CertificateError
+        return false if soft
+
+        raise ValidationError.new('Invalid certificate', :invalid_certificate_in_request)
+      end
 
         # check cert matches registered idp cert
         fingerprint = fingerprint_cert(cert, options)
@@ -75,6 +72,29 @@ module SamlIdp
         end
 
         validate_doc(base64_cert, soft, options)
+      end
+
+      def validate_with_sha256(idp_certificate, options = {})
+        if request_cert && Base64.decode64(request_cert) != idp_certificate.to_der
+          raise ValidationError.new('Request certificate not valid or registered', :request_cert_not_registered)
+        end
+
+        validate_doc(request_cert, false, options)
+      end
+
+      def request_cert
+        @request_cert ||= if cert_element.text.blank?
+          raise ValidationError.new(
+            'Certificate element present in response (ds:X509Certificate) but evaluating to nil',
+            :no_certificate_in_request
+          )
+        end
+
+        cert_element.text
+      end
+
+      def valid_cert(cert_text)
+        OpenSSL::X509::Certificate.new(cert_text)
       end
 
       def validate_doc(base64_cert, soft = true, options = {})
@@ -111,7 +131,6 @@ module SamlIdp
       end
 
       def find_base64_cert(options)
-        cert_element = document.at_xpath('//ds:X509Certificate | //X509Certificate', DS_NS)
         if cert_element
           return cert_element.text if cert_element.text.present?
 
@@ -236,8 +255,9 @@ module SamlIdp
         cert = OpenSSL::X509::Certificate.new(cert_text)
         signature_algorithm = algorithm(sig_alg)
 
-        if signature_algorithm != SamlIdp.config.algorithm
-          return false if soft
+        if !soft && signature_algorithm != SamlIdp.config.algorithm
+          # remove comment when we are sure this wont break partners
+          # return false if soft
 
           raise ValidationError.new(
             "Signature Algorithm needs to be #{SamlIdp.config.algorithm.new.name}",
@@ -296,6 +316,10 @@ module SamlIdp
         document.at_xpath(
           "//ec:InclusiveNamespaces", { 'ec' =>  C14N }
         )&.attr('PrefixList')&.split(' ') || []
+      end
+
+      def cert_element
+        @cert_elementy || document.at_xpath('//ds:X509Certificate | //X509Certificate', DS_NS)
       end
 
       def log(msg, level: :debug)

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -257,9 +257,9 @@ module SamlIdp
         cert = OpenSSL::X509::Certificate.new(cert_text)
         signature_algorithm = algorithm(sig_alg)
 
+        # remove if !soft when we are sure this wont break partners
         if !soft && signature_algorithm != SamlIdp.config.algorithm
-          # remove comment when we are sure this wont break partners
-          # return false if soft
+          return false if soft
 
           raise ValidationError.new(
             "Signature Algorithm needs to be #{SamlIdp.config.algorithm.new.name}",

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -93,6 +93,7 @@ module SamlIdp
         cert_element.text
       end
 
+      # @return [Array(OpenSSL::X509::Certificate, false), Array(nil, Error)] tuple of (cert, error)
       def valid_cert(cert_text)
         return OpenSSL::X509::Certificate.new(cert_text), false
       rescue OpenSSL::X509::CertificateError

--- a/spec/support/certificate_helpers.rb
+++ b/spec/support/certificate_helpers.rb
@@ -28,14 +28,6 @@ module CertificateHelpers
     OpenSSL::X509::Certificate.new(File.read('spec/support/certificates/too_short_cert.crt'))
   end
 
-  def add_cert_boundaries(cert_text)
-    <<~TEXT
-      -----BEGIN CERTIFICATE-----
-      #{cert_text}
-      -----END CERTIFICATE-----
-    TEXT
-  end
-
   def remove_cert_boundaries(cert)
     cert.
       gsub("-----BEGIN CERTIFICATE-----\n", '').

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -8,7 +8,7 @@ module SamlIdp
     let(:auth_request) { custom_saml_request }
     let(:request) { Request.from_deflated_request(auth_request) }
     let(:base64_cert_text) { saml_settings.certificate }
-    let(:base64_cert) { OpenSSL::X509::Certificate.new(add_cert_boundaries(saml_settings.certificate)) }
+    let(:base64_cert) { OpenSSL::X509::Certificate.new(Base64.decode64(saml_settings.certificate)) }
 
     subject do
       request.send(:document).signed_document
@@ -170,21 +170,16 @@ module SamlIdp
         context 'when using SHA1 as a signing algorithm' do
           let(:algorithm) { '1' }
 
-          it 'raises an error' do
+          it 'validates using SHA1' do
             fingerprint = OpenSSL::Digest::SHA1.new(base64_cert.to_der).hexdigest
-            expect { subject.validate(fingerprint, false) }.to(
-              raise_error(
-                SamlIdp::XMLSecurity::SignedDocument::ValidationError,
-                'Signature Algorithm needs to be SHA256'
-              )
-            )
+            expect(subject.validate(fingerprint)).to be true
           end
         end
 
         context 'when using SHA256 as a signing algorithm' do
           let(:algorithm) { '256' }
 
-          it 'validate using SHA256' do
+          it 'validates using SHA256' do
             fingerprint = OpenSSL::Digest::SHA256.new(base64_cert.to_der).hexdigest
             expect(subject.validate(fingerprint)).to be true
           end
@@ -193,28 +188,129 @@ module SamlIdp
         context 'when using SHA384 as a signing algorithm' do
           let(:algorithm) { '384' }
 
-          it 'raises an error' do
+          it 'validates using SHA384' do
             fingerprint = OpenSSL::Digest::SHA384.new(base64_cert.to_der).hexdigest
-            expect { subject.validate(fingerprint, false) }.to(
-              raise_error(
-                SamlIdp::XMLSecurity::SignedDocument::ValidationError,
-                'Signature Algorithm needs to be SHA256'
-              )
-            )
+            expect(subject.validate(fingerprint)).to be true
           end
         end
 
         context 'when using SHA512 as a signing algorithm' do
           let(:algorithm) { '512' }
 
-          it 'raises an error' do
+          it 'validates using SHA512' do
             fingerprint = OpenSSL::Digest::SHA512.new(base64_cert.to_der).hexdigest
-            expect { subject.validate(fingerprint, false) }.to(
+            expect(subject.validate(fingerprint)).to be true
+          end
+        end
+      end
+    end
+
+    describe '#validate_with_sha256' do
+      context 'with an embedded request' do
+
+        context 'when the request certificate does not match an idp certificate' do
+          let(:cert_element) { double Nokogiri::XML::Element }
+          let(:wrong_cert) { remove_cert_boundaries(custom_idp_x509_cert) }
+
+          before do
+            allow(subject.document).to receive(:at_xpath).
+              with('//ds:X509Certificate | //X509Certificate', ds_namespace).
+              and_return(cert_element)
+
+            allow(cert_element).to receive(:text).and_return(wrong_cert)
+          end
+
+          it 'raises an error' do
+            expect { subject.validate_with_sha256(base64_cert) }.to(
               raise_error(
                 SamlIdp::XMLSecurity::SignedDocument::ValidationError,
-                'Signature Algorithm needs to be SHA256'
+                'Request certificate not valid or registered'
               )
             )
+          end
+        end
+
+        context 'when the request certificate is invalid' do
+          let(:cert_element) { double Nokogiri::XML::Element }
+          let(:wrong_cert) { 'invalid_cert' }
+
+          before do
+            allow(subject.document).to receive(:at_xpath).
+              with('//ds:X509Certificate | //X509Certificate', ds_namespace).
+              and_return(cert_element)
+
+            allow(cert_element).to receive(:text).and_return(wrong_cert)
+          end
+
+          it 'raises an error' do
+            expect { subject.validate_with_sha256(base64_cert) }.to(
+              raise_error(
+                SamlIdp::XMLSecurity::SignedDocument::ValidationError,
+                'Request certificate not valid or registered'
+              )
+            )
+          end
+        end
+
+        context 'with different signing algorithms' do
+          let(:signature_method) { "http://www.w3.org/2001/04/xmldsig-more#rsa-sha#{algorithm}" }
+          let(:digest_method) { "http://www.w3.org/2001/04/xmldsig-more#rsa-sha#{algorithm}" }
+
+          let(:auth_request) do
+            custom_saml_request(
+              security_overrides: {
+                signature_method:,
+                digest_method:,
+              }
+            )
+          end
+
+          context 'when using SHA1 as a signing algorithm' do
+            let(:algorithm) { '1' }
+
+            it 'raises an error' do
+              fingerprint = OpenSSL::Digest::SHA1.new(base64_cert.to_der).hexdigest
+              expect { subject.validate_with_sha256(base64_cert) }.to(
+                raise_error(
+                  SamlIdp::XMLSecurity::SignedDocument::ValidationError,
+                  'Signature Algorithm needs to be SHA256'
+                )
+              )
+            end
+          end
+
+          context 'when using SHA256 as a signing algorithm' do
+            let(:algorithm) { '256' }
+
+            it 'validate using SHA256' do
+              expect(subject.validate_with_sha256(base64_cert)).to be true
+            end
+          end
+
+          context 'when using SHA384 as a signing algorithm' do
+            let(:algorithm) { '384' }
+
+            it 'raises an error' do
+              expect { subject.validate_with_sha256(base64_cert) }.to(
+                raise_error(
+                  SamlIdp::XMLSecurity::SignedDocument::ValidationError,
+                  'Signature Algorithm needs to be SHA256'
+                )
+              )
+            end
+          end
+
+          context 'when using SHA512 as a signing algorithm' do
+            let(:algorithm) { '512' }
+
+            it 'raises an error' do
+              expect { subject.validate_with_sha256(base64_cert) }.to(
+                raise_error(
+                  SamlIdp::XMLSecurity::SignedDocument::ValidationError,
+                  'Signature Algorithm needs to be SHA256'
+                )
+              )
+            end
           end
         end
       end


### PR DESCRIPTION
Recently, I [merged code](https://github.com/18F/saml_idp/pull/124) to add an add an explicit error for when requests are using anything but SHA256, our desired encryption algorithm, for the signature method algorithm. 

However, when I went to add this to the Idp, I tried to write some tests to replicate the original behavior and was unable to. This is when I determined (with the help of @jmhooper) that we actually do not seem to have validations for the signature method algorithm, but we ARE doing some determinations around whether the digest method algorithm is SHA256. We use that algorithm to ensure that the cert that is passed in the request matches a Service Provider's registered certs, but that code is complex and could be streamlined by just directly comparing the certificates (if the certificate is embedded in the request.)

Updating this means there is a possibility of a currently valid request being marked as invalid, or vice versa, which means there are opportunities for us to find a different matching certificate. 

This change:
-  creates a new entry point (`validate_with_sha256`) to the XmlSecurity class that we can call so that we can set up event tracking in the IdP in order to determine if any integrations will break.
- introduces a new, easier to understand (imo) way to compare the certs that we can use to replace the [existing fingerprint code](https://github.com/18F/saml_idp/blob/main/lib/saml_idp/xml_security.rb#L54-L77) (we don't need to mess around with fingerprints, since we have the certificates)