### PR TITLE
Fix bug when signature is params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.23.1.pre.18f)
+    saml_idp (0.23.3.pre.18f)
       activesupport
       builder
       faraday

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.23.2-18f'.freeze
+  VERSION = '0.23.3-18f'.freeze
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -79,10 +79,12 @@ module SamlIdp
           raise ValidationError.new('Request certificate not valid or registered', :request_cert_not_registered)
         end
 
-        validate_doc(request_cert, false, options)
+        validate_doc(Base64.encode64(idp_certificate.to_pem), false, options)
       end
 
       def request_cert
+        return false if cert_element.blank?
+
         if cert_element.text.blank?
           raise ValidationError.new(
             'Certificate element present in response (ds:X509Certificate) but evaluating to nil',

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -477,6 +477,16 @@ module SamlIdp
               expect(subject.sha256_validation_matching_cert).to eq cert
             end
 
+            describe 'when the request is not embedded' do
+              let(:security_overrides) {{ embed_sign: false }}
+              let(:params) { encoded_request.symbolize_keys! }
+              subject { described_class.from_deflated_request(params[:SAMLRequest], get_params: params) }
+
+              it 'returns the cert' do
+                expect(subject.sha256_validation_matching_cert).to eq cert
+              end
+            end
+
             context 'when the signature algorithm is not right' do
               let(:security_overrides) do
                 {

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -10,7 +10,11 @@ module SamlRequestMacros
       )
     )
 
-    CGI.unescape(auth_url.split('=').last)
+    if security_overrides[:embed_sign] == false
+      Rack::Utils.parse_nested_query URI(auth_url).query
+    else
+      CGI.unescape(auth_url.split('=').last)
+    end
   end
 
   def custom_logout_request(overrides: {}, security_overrides: {})

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -11,7 +11,7 @@ module SamlRequestMacros
     )
 
     if security_overrides[:embed_sign] == false
-      Rack::Utils.parse_nested_query URI(auth_url).query
+      Rack::Utils.parse_nested_query(URI(auth_url).query)
     else
       CGI.unescape(auth_url.split('=').last)
     end


### PR DESCRIPTION
There is a bug in https://github.com/18F/saml_idp/pull/126. When the signature is passed through as a parameter rather than embedded in the certificate, it was throwing `NoMethodError` because the `cert_element` was evaluating to `nil`