### PR TITLE
Support AES-GCM encryption algorithms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.23.3.pre.18f)
+    saml_idp (0.23.4.pre.18f)
       activesupport
       builder
       faraday

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,7 +317,7 @@ DEPENDENCIES
   simplecov (~> 0.22.0)
   sqlite3
   timecop
-  xmlenc (>= 0.7.1)
+  xmlenc (>= 0.8.0)
 
 BUNDLED WITH
    2.5.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       pkcs11
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actioncable (7.1.3.4)
       actionpack (= 7.1.3.4)

--- a/lib/saml_idp/encryptor.rb
+++ b/lib/saml_idp/encryptor.rb
@@ -3,6 +3,14 @@ module SamlIdp
   class Encryptor
     attr_accessor :encryption_key, :block_encryption, :key_transport, :cert
 
+    ENCRYPTION_ALGORITHMS_NS = {
+      'aes128-cbc' => 'http://www.w3.org/2001/04/xmlenc#aes128-cbc',
+      'aes256-cbc' => 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+      'aes128-gcm' => 'http://www.w3.org/2009/xmlenc11#aes128-gcm',
+      'aes192-gcm' => 'http://www.w3.org/2009/xmlenc11#aes192-gcm',
+      'aes256-gcm' => 'http://www.w3.org/2009/xmlenc11#aes256-gcm',
+    }
+
     def initialize(opts)
       self.block_encryption = opts[:block_encryption]
       self.key_transport = opts[:key_transport]
@@ -37,22 +45,13 @@ module SamlIdp
     # Encryption algorithms enumerated in:
     # https://github.com/digidentity/xmlenc/blob/937ca2f/lib/xmlenc/encrypted_data.rb#L3-L10
     def block_encryption_ns
-      case block_encryption
-      when 'tripledes-cbc'
-        'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
-      when 'aes128-cbc'
-        'http://www.w3.org/2001/04/xmlenc#aes128-cbc'
-      when 'aes256-cbc'
-        'http://www.w3.org/2001/04/xmlenc#aes256-cbc'
-      when 'aes128-gcm'
-        'http://www.w3.org/2009/xmlenc11#aes128-gcm'
-      when 'aes192-gcm'
-        'http://www.w3.org/2009/xmlenc11#aes192-gcm'
-      when 'aes256-gcm'
-        'http://www.w3.org/2009/xmlenc11#aes256-gcm'
-      else
-        "http://www.w3.org/2009/xmlenc11##{block_encryption}"
-      end
+      ns = ENCRYPTION_ALGORITHMS_NS[block_encryption]
+      return ns if !ns.nil?
+
+      raise ValidationError.new(
+        "Invalid encryption algorithm #{block_encryption}",
+        :invalid_encryption_algorithm
+      )
     end
     private :block_encryption_ns
 

--- a/lib/saml_idp/encryptor.rb
+++ b/lib/saml_idp/encryptor.rb
@@ -34,8 +34,25 @@ module SamlIdp
     end
     private :openssl_cert
 
+    # Encryption algorithms enumerated in:
+    # https://github.com/digidentity/xmlenc/blob/937ca2f/lib/xmlenc/encrypted_data.rb#L3-L10
     def block_encryption_ns
-      "http://www.w3.org/2001/04/xmlenc##{block_encryption}"
+      case block_encryption
+        when 'tripledes-cbc'
+          'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
+        when 'aes128-cbc'
+        'http://www.w3.org/2001/04/xmlenc#aes128-cbc'
+        when 'aes256-cbc'
+          'http://www.w3.org/2001/04/xmlenc#aes256-cbc'
+        when 'aes128-gcm'
+          'http://www.w3.org/2009/xmlenc11#aes128-gcm'
+        when 'aes192-gcm'
+          'http://www.w3.org/2009/xmlenc11#aes192-gcm'
+        when 'aes256-gcm'
+          'http://www.w3.org/2009/xmlenc11#aes256-gcm'
+        else
+          "http://www.w3.org/2009/xmlenc11##{block_encryption}"
+      end
     end
     private :block_encryption_ns
 

--- a/lib/saml_idp/encryptor.rb
+++ b/lib/saml_idp/encryptor.rb
@@ -38,20 +38,20 @@ module SamlIdp
     # https://github.com/digidentity/xmlenc/blob/937ca2f/lib/xmlenc/encrypted_data.rb#L3-L10
     def block_encryption_ns
       case block_encryption
-        when 'tripledes-cbc'
-          'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
-        when 'aes128-cbc'
-        'http://www.w3.org/2001/04/xmlenc#aes128-cbc'
-        when 'aes256-cbc'
-          'http://www.w3.org/2001/04/xmlenc#aes256-cbc'
-        when 'aes128-gcm'
-          'http://www.w3.org/2009/xmlenc11#aes128-gcm'
-        when 'aes192-gcm'
-          'http://www.w3.org/2009/xmlenc11#aes192-gcm'
-        when 'aes256-gcm'
-          'http://www.w3.org/2009/xmlenc11#aes256-gcm'
-        else
-          "http://www.w3.org/2009/xmlenc11##{block_encryption}"
+      when 'tripledes-cbc'
+        'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
+      when 'aes128-cbc'
+      'http://www.w3.org/2001/04/xmlenc#aes128-cbc'
+      when 'aes256-cbc'
+        'http://www.w3.org/2001/04/xmlenc#aes256-cbc'
+      when 'aes128-gcm'
+        'http://www.w3.org/2009/xmlenc11#aes128-gcm'
+      when 'aes192-gcm'
+        'http://www.w3.org/2009/xmlenc11#aes192-gcm'
+      when 'aes256-gcm'
+        'http://www.w3.org/2009/xmlenc11#aes256-gcm'
+      else
+        "http://www.w3.org/2009/xmlenc11##{block_encryption}"
       end
     end
     private :block_encryption_ns

--- a/lib/saml_idp/encryptor.rb
+++ b/lib/saml_idp/encryptor.rb
@@ -41,7 +41,7 @@ module SamlIdp
       when 'tripledes-cbc'
         'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
       when 'aes128-cbc'
-      'http://www.w3.org/2001/04/xmlenc#aes128-cbc'
+        'http://www.w3.org/2001/04/xmlenc#aes128-cbc'
       when 'aes256-cbc'
         'http://www.w3.org/2001/04/xmlenc#aes256-cbc'
       when 'aes128-gcm'

--- a/lib/saml_idp/encryptor.rb
+++ b/lib/saml_idp/encryptor.rb
@@ -3,6 +3,8 @@ module SamlIdp
   class Encryptor
     attr_accessor :encryption_key, :block_encryption, :key_transport, :cert
 
+    # Encryption algorithms enumerated in:
+    # https://github.com/digidentity/xmlenc/blob/937ca2f/lib/xmlenc/encrypted_data.rb#L3-L10
     ENCRYPTION_ALGORITHMS_NS = {
       'aes128-cbc' => 'http://www.w3.org/2001/04/xmlenc#aes128-cbc',
       'aes256-cbc' => 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
@@ -42,16 +44,8 @@ module SamlIdp
     end
     private :openssl_cert
 
-    # Encryption algorithms enumerated in:
-    # https://github.com/digidentity/xmlenc/blob/937ca2f/lib/xmlenc/encrypted_data.rb#L3-L10
     def block_encryption_ns
-      ns = ENCRYPTION_ALGORITHMS_NS[block_encryption]
-      return ns if !ns.nil?
-
-      raise ValidationError.new(
-        "Invalid encryption algorithm #{block_encryption}",
-        :invalid_encryption_algorithm
-      )
+      ENCRYPTION_ALGORITHMS_NS[block_encryption]
     end
     private :block_encryption_ns
 

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.23.3-18f'.freeze
+  VERSION = '0.23.4-18f'.freeze
 end

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -42,6 +42,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~> 0.22.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency('timecop')
-  s.add_development_dependency('xmlenc', '>= 0.7.1')
+  s.add_development_dependency('xmlenc', '>= 0.8.0')
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'saml_idp/encryptor'
 
 describe SamlIdp::Controller do
   include SamlIdp::Controller
@@ -56,13 +57,6 @@ describe SamlIdp::Controller do
     end
 
     let(:principal) { double email_address: 'foo@example.com' }
-    let(:encryption_opts) do
-      {
-        cert: SamlIdp::Default::X509_CERTIFICATE,
-        block_encryption: 'aes256-cbc',
-        key_transport: 'rsa-oaep-mgf1p',
-      }
-    end
 
     it 'creates a SAML Response' do
       saml_response = encode_response(principal)
@@ -116,17 +110,26 @@ describe SamlIdp::Controller do
         expect(response.is_valid?).to be_truthy
       end
 
-      it 'encrypts SAML Response assertion' do
-        self.algorithm = algorithm_name
-        saml_response = encode_response(principal, encryption: encryption_opts)
-        resp_settings = saml_settings
-        resp_settings.private_key = SamlIdp::Default::SECRET_KEY
-        response = OneLogin::RubySaml::Response.new(saml_response, settings: resp_settings)
-        expect(response.document.to_s).not_to match('foo@example.com')
-        expect(response.decrypted_document.to_s).to match('foo@example.com')
-        expect(response.name_id).to eq('foo@example.com')
-        expect(response.issuers.first).to eq('http://example.com')
-        expect(response.is_valid?).to be_truthy
+      SamlIdp::Encryptor::ENCRYPTION_ALGORITHMS_NS.keys.each do |encryption_algorithm|
+        it "encrypts SAML Response assertion using #{encryption_algorithm}" do
+          self.algorithm = algorithm_name
+          puts encryption_algorithm
+          encryption_opts = {
+            cert: SamlIdp::Default::X509_CERTIFICATE,
+            block_encryption: encryption_algorithm,
+            key_transport: 'rsa-oaep-mgf1p',
+          }
+
+          saml_response = encode_response(principal, encryption: encryption_opts)
+          resp_settings = saml_settings
+          resp_settings.private_key = SamlIdp::Default::SECRET_KEY
+          response = OneLogin::RubySaml::Response.new(saml_response, settings: resp_settings)
+          expect(response.document.to_s).not_to match('foo@example.com')
+          expect(response.decrypted_document.to_s).to match('foo@example.com')
+          expect(response.name_id).to eq('foo@example.com')
+          expect(response.issuers.first).to eq('http://example.com')
+          expect(response.is_valid?).to be_truthy
+        end
       end
     end
   end

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -113,7 +113,6 @@ describe SamlIdp::Controller do
       SamlIdp::Encryptor::ENCRYPTION_ALGORITHMS_NS.keys.each do |encryption_algorithm|
         it "encrypts SAML Response assertion using #{encryption_algorithm}" do
           self.algorithm = algorithm_name
-          puts encryption_algorithm
           encryption_opts = {
             cert: SamlIdp::Default::X509_CERTIFICATE,
             block_encryption: encryption_algorithm,

--- a/spec/lib/saml_idp/encryptor_spec.rb
+++ b/spec/lib/saml_idp/encryptor_spec.rb
@@ -32,5 +32,26 @@ module SamlIdp
 
       expect(encrypted_doc.remove_namespaces!.xpath('//KeyName')).to be_empty
     end
+
+    context 'gcm encryption algorithm' do
+      let(:encryption_opts) do
+        {
+          cert: Default::X509_CERTIFICATE,
+          block_encryption: 'aes256-gcm',
+          key_transport: 'rsa-oaep-mgf1p',
+        }
+      end
+
+      it 'encrypts XML' do
+        raw_xml = '<foo>bar</foo>'
+        encrypted_xml = subject.encrypt(raw_xml)
+        expect(encrypted_xml).not_to match 'bar'
+        encrypted_doc = Nokogiri::XML::Document.parse(encrypted_xml)
+        encrypted_data = Xmlenc::EncryptedData.new(encrypted_doc.at_xpath('//xenc:EncryptedData',
+                                                                          Xmlenc::NAMESPACES))
+        decrypted_xml = encrypted_data.decrypt(subject.encryption_key)
+        expect(decrypted_xml).to eq(raw_xml)
+      end
+    end
   end
 end

--- a/spec/lib/saml_idp/encryptor_spec.rb
+++ b/spec/lib/saml_idp/encryptor_spec.rb
@@ -14,15 +14,18 @@ module SamlIdp
 
     subject { described_class.new encryption_opts }
 
-    it 'encrypts XML' do
-      raw_xml = '<foo>bar</foo>'
-      encrypted_xml = subject.encrypt(raw_xml)
-      expect(encrypted_xml).not_to match 'bar'
-      encrypted_doc = Nokogiri::XML::Document.parse(encrypted_xml)
-      encrypted_data = Xmlenc::EncryptedData.new(encrypted_doc.at_xpath('//xenc:EncryptedData',
-                                                                        Xmlenc::NAMESPACES))
-      decrypted_xml = encrypted_data.decrypt(subject.encryption_key)
-      expect(decrypted_xml).to eq(raw_xml)
+    SamlIdp::Encryptor::ENCRYPTION_ALGORITHMS_NS.keys.each do |encryption_algorithm|
+      it "encrypts XML with #{encryption_algorithm}" do
+        encryption_opts[:block_encryption] = encryption_algorithm
+        raw_xml = '<foo>bar</foo>'
+        encrypted_xml = subject.encrypt(raw_xml)
+        expect(encrypted_xml).not_to match 'bar'
+        encrypted_doc = Nokogiri::XML::Document.parse(encrypted_xml)
+        encrypted_data = Xmlenc::EncryptedData.new(encrypted_doc.at_xpath('//xenc:EncryptedData',
+                                                                          Xmlenc::NAMESPACES))
+        decrypted_xml = encrypted_data.decrypt(subject.encryption_key)
+        expect(decrypted_xml).to eq(raw_xml)
+      end
     end
 
     it 'does not have a KeyName element' do
@@ -33,24 +36,13 @@ module SamlIdp
       expect(encrypted_doc.remove_namespaces!.xpath('//KeyName')).to be_empty
     end
 
-    context 'gcm encryption algorithm' do
-      let(:encryption_opts) do
-        {
-          cert: Default::X509_CERTIFICATE,
-          block_encryption: 'aes256-gcm',
-          key_transport: 'rsa-oaep-mgf1p',
-        }
-      end
+    context 'invalid block_encryption' do
+      it 'raises an exception' do
+        encryption_opts[:block_encryption] = 'abc123'
 
-      it 'encrypts XML' do
-        raw_xml = '<foo>bar</foo>'
-        encrypted_xml = subject.encrypt(raw_xml)
-        expect(encrypted_xml).not_to match 'bar'
-        encrypted_doc = Nokogiri::XML::Document.parse(encrypted_xml)
-        encrypted_data = Xmlenc::EncryptedData.new(encrypted_doc.at_xpath('//xenc:EncryptedData',
-                                                                          Xmlenc::NAMESPACES))
-        decrypted_xml = encrypted_data.decrypt(subject.encryption_key)
-        expect(decrypted_xml).to eq(raw_xml)
+        expect do
+          subject.encrypt('<foo>bar</foo>')
+        end.to raise_error(Xmlenc::UnsupportedError)
       end
     end
   end


### PR DESCRIPTION
closes https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/139

xmlenc added support for AES-GCM in version [0.8.0](https://github.com/digidentity/xmlenc/releases/tag/v0.8.0) in August 2021. It doesn't appear that [upstream saml_idp](https://github.com/saml-idp/saml_idp/blob/78c1868/lib/saml_idp/encryptor.rb#L40-L42) supports AES-GCM either.

This PR adds support for using AES-GCM in the `block_encryption` option.

I did some light testing locally with our sample SAML service provider, and it everything seemed to work as expected.

