### PR TITLE
Validate signature algorithm correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.23.4.pre.18f)
+    saml_idp (0.23.5.pre.18f)
       activesupport
       builder
       faraday

--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -73,9 +73,9 @@ module Saml
       end
       private :options_have_signature
 
-      def valid_signature?(fingerprint, options = {})
+      def valid_signature?(cert, options = {})
         (signed? || options_have_signature(options)) &&
-          signed_document.validate(fingerprint, :soft, options)
+          signed_document.validate(cert, options)
       end
 
       def signed_document
@@ -86,8 +86,8 @@ module Saml
         Namespaces::SIGNATURE
       end
 
-      def gather_errors(fingerprint, options = {})
-        signed_document.validate(fingerprint, false, options)
+      def gather_errors(cert, options = {})
+        signed_document.validate(cert, options, soft: false)
       rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError => e
         { cert: options[:cert].serial.to_s, error_code: e.error_code }
       end

--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -89,7 +89,7 @@ module Saml
       def gather_errors(cert, options = {})
         signed_document.validate(cert, options, soft: false)
       rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError => e
-        { cert: options[:cert].serial.to_s, error_code: e.error_code }
+        { cert: cert.serial.to_s, error_code: e.error_code }
       end
 
       def valid_sig_with_sha256?(cert, options = {})

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -150,7 +150,7 @@ module SamlIdp
       return nil unless signed?
 
       Array(service_provider.certs).find do |cert|
-        document.valid_signature?(cert, options.merge(cert:))
+        document.valid_signature?(cert, options)
       end
     end
 
@@ -166,7 +166,7 @@ module SamlIdp
       return [{ cert: nil, error_code: :no_registered_certs }] if service_provider.certs.blank?
 
       Array(service_provider.certs).map do |cert|
-        document.gather_errors(cert, options.merge(cert:))
+        document.gather_errors(cert, options)
       end
     end
 

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -150,19 +150,7 @@ module SamlIdp
       return nil unless signed?
 
       Array(service_provider.certs).find do |cert|
-        document.valid_signature?(
-          fingerprint(cert),
-          options.merge(cert:)
-        )
-      end
-    end
-
-    def sha256_validation_matching_cert
-      return nil unless signed?
-
-      Array(service_provider.certs).find do |cert|
-        document.valid_sig_with_sha256?(cert, options)
-      rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
+        document.valid_signature?(cert, options.merge(cert:))
       end
     end
 
@@ -178,15 +166,8 @@ module SamlIdp
       return [{ cert: nil, error_code: :no_registered_certs }] if service_provider.certs.blank?
 
       Array(service_provider.certs).map do |cert|
-        document.gather_errors(
-          fingerprint(cert),
-          options.merge(cert:)
-        )
+        document.gather_errors(cert, options.merge(cert:))
       end
-    end
-
-    def fingerprint(cert)
-      OpenSSL::Digest::SHA256.new(cert.to_der).hexdigest
     end
 
     def signed?

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -6,6 +6,7 @@ module SamlIdp
   class ServiceProvider
     include Attributeable
     attribute :identifier
+    # certs is a list of OpenSSl::X509::Certificate objects
     attribute :certs
     attribute :metadata_url
     attribute :validate_signature

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.23.4-18f'.freeze
+  VERSION = '0.23.5-18f'.freeze
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -41,7 +41,7 @@ module SamlIdp
 
       C14N = 'http://www.w3.org/2001/10/xml-exc-c14n#'
       DSIG = 'http://www.w3.org/2000/09/xmldsig#'
-      DS_NS = { "ds" => DSIG }
+      DS_NS = { 'ds' => DSIG }
 
       attr_accessor :document
 
@@ -49,37 +49,15 @@ module SamlIdp
         @document = Nokogiri.XML(response)
       end
 
-      def validate(idp_cert_fingerprint, soft = true, options = {})
-        log 'Validate the fingerprint'
-        base64_cert = find_base64_cert(options)
-        cert_text = Base64.decode64(base64_cert)
-
-        cert, error = valid_cert(cert_text)
-        if error.present?
+      def validate(idp_certificate, options = {}, soft: true)
+        if request_cert && Base64.decode64(request_cert) != idp_certificate.to_der
           return false if soft
 
-          raise error
+          raise ValidationError.new('Request certificate not valid or registered',
+                                    :request_cert_not_registered)
         end
 
-        # check cert matches registered idp cert
-        fingerprint = fingerprint_cert(cert, options)
-        sha1_fingerprint = fingerprint_cert_sha1(cert)
-        plain_idp_cert_fingerprint = idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/, '').downcase
-
-        if fingerprint != plain_idp_cert_fingerprint && sha1_fingerprint != plain_idp_cert_fingerprint
-          return soft ? false : (raise ValidationError.new('Fingerprint mismatch',
-                                                           :fingerprint_mismatch))
-        end
-
-        validate_doc(base64_cert, soft, options)
-      end
-
-      def validate_with_sha256(idp_certificate, options = {})
-        if request_cert && Base64.decode64(request_cert) != idp_certificate.to_der
-          raise ValidationError.new('Request certificate not valid or registered', :request_cert_not_registered)
-        end
-
-        validate_doc(Base64.encode64(idp_certificate.to_pem), false, options)
+        validate_doc(Base64.encode64(idp_certificate.to_pem), soft, options)
       end
 
       def request_cert
@@ -93,13 +71,6 @@ module SamlIdp
         end
 
         cert_element.text
-      end
-
-      # @return [Array(OpenSSL::X509::Certificate, false), Array(nil, Error)] tuple of (cert, error)
-      def valid_cert(cert_text)
-        return OpenSSL::X509::Certificate.new(cert_text), false
-      rescue OpenSSL::X509::CertificateError
-        return nil, ValidationError.new('Invalid certificate', :invalid_certificate_in_request)
       end
 
       def validate_doc(base64_cert, soft = true, options = {})
@@ -133,30 +104,6 @@ module SamlIdp
 
       def fingerprint_cert_sha1(cert)
         OpenSSL::Digest::SHA1.hexdigest(cert.to_der)
-      end
-
-      def find_base64_cert(options)
-        if cert_element
-          return cert_element.text if cert_element.text.present?
-
-          raise ValidationError.new(
-            'Certificate element present in response (ds:X509Certificate) but evaluating to nil', :no_certificate_in_request
-          )
-        elsif options[:cert]
-          if options[:cert].is_a?(String)
-            options[:cert]
-          elsif options[:cert].is_a?(OpenSSL::X509::Certificate)
-            Base64.encode64(options[:cert].to_pem)
-          else
-            raise ValidationError.new(
-              'options[:cert] must be Base64-encoded String or OpenSSL::X509::Certificate', :not_base64_or_cert
-            )
-          end
-        else
-          raise ValidationError.new(
-            'Certificate element missing in response (ds:X509Certificate) and not provided in options[:cert]', :cert_missing
-          )
-        end
       end
 
       def request?
@@ -260,8 +207,7 @@ module SamlIdp
         cert = OpenSSL::X509::Certificate.new(cert_text)
         signature_algorithm = algorithm(sig_alg)
 
-        # remove if !soft when we are sure this wont break partners
-        if !soft && signature_algorithm != SamlIdp.config.algorithm
+        if signature_algorithm != SamlIdp.config.algorithm
           return false if soft
 
           raise ValidationError.new(
@@ -319,7 +265,7 @@ module SamlIdp
 
       def extract_inclusive_namespaces
         document.at_xpath(
-          "//ec:InclusiveNamespaces", { 'ec' =>  C14N }
+          '//ec:InclusiveNamespaces', { 'ec' => C14N }
         )&.attr('PrefixList')&.split(' ') || []
       end
 

--- a/spec/lib/saml_idp/metadata_builder_spec.rb
+++ b/spec/lib/saml_idp/metadata_builder_spec.rb
@@ -1,10 +1,9 @@
 require 'spec_helper'
 module SamlIdp
   describe MetadataBuilder do
-
     describe '#signed' do
       it 'signs valid xml' do
-        expect(Saml::XML::Document.parse(subject.signed).valid_signature?(Default::FINGERPRINT)).to be_truthy
+        expect(Saml::XML::Document.parse(subject.signed).valid_signature?(default_cert)).to be_truthy
       end
 
       it 'signs valid xml with a custom cert and private key' do
@@ -13,7 +12,7 @@ module SamlIdp
           custom_idp_x509_cert,
           custom_idp_secret_key
         )
-        expect(Saml::XML::Document.parse(subject.signed).valid_signature?(custom_idp_x509_cert_fingerprint)).to be_truthy
+        expect(Saml::XML::Document.parse(subject.signed).valid_signature?(custom_cert)).to be_truthy
       end
     end
 

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -81,7 +81,7 @@ module SamlIdp
           expect(subject.valid_signature?).to be true
         end
 
-        it "correctly indicates that it is signed" do
+        it 'correctly indicates that it is signed' do
           expect(subject.signed?).to be true
         end
       end
@@ -169,7 +169,6 @@ module SamlIdp
         end
       end
 
-
       describe 'unspecified name id format' do
         let(:local_overrides) { { name_identifier_format: nil } }
 
@@ -184,7 +183,7 @@ module SamlIdp
 
       subject do
         described_class.from_deflated_request(
-          encoded_request["SAMLRequest"],
+          encoded_request['SAMLRequest'],
           get_params: encoded_request
         )
       end
@@ -298,6 +297,7 @@ module SamlIdp
           let(:request_saml) do
             "<saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:RequestedAuthnContext Comparison='exact'></samlp:RequestedAuthnContext>"
           end
+
           subject { described_class.new request_saml }
 
           it 'is not valid' do
@@ -320,7 +320,7 @@ module SamlIdp
             "<samlp:LogoutRequest Destination='http://localhost:3000/saml/logout' xmlns='urn:oasis:names:tc:SAML:2.0:protocol'><Issuer xmlns='urn:oasis:names:tc:SAML:2.0:assertion'>http://example.com</Issuer></samlp:LogoutRequest>"
           end
 
-          subject { described_class.new auth_request + logout_request + "</samlp:AuthnRequest>"}
+          subject { described_class.new auth_request + logout_request + '</samlp:AuthnRequest>' }
 
           it 'is not valid' do
             expect(subject.valid?).to eq false
@@ -351,7 +351,7 @@ module SamlIdp
 
             subject do
               described_class.from_deflated_request(
-                encoded_request["SAMLRequest"],
+                encoded_request['SAMLRequest'],
                 get_params: encoded_request
               )
             end
@@ -376,7 +376,7 @@ module SamlIdp
 
           subject do
             described_class.from_deflated_request(
-              encoded_request["SAMLRequest"],
+              encoded_request['SAMLRequest'],
               get_params: encoded_request
             )
           end
@@ -429,7 +429,7 @@ module SamlIdp
           end
 
           describe 'the cert does not match the assertion cert' do
-            let(:cert) { OpenSSL::X509::Certificate.new(custom_idp_x509_cert) }
+            let(:cert) { custom_cert }
 
             it 'returns nil' do
               expect(subject.matching_cert).to be_nil
@@ -438,96 +438,12 @@ module SamlIdp
         end
 
         describe 'multiple certs' do
-          let(:not_matching_cert) { OpenSSL::X509::Certificate.new(custom_idp_x509_cert) }
+          let(:not_matching_cert) { custom_cert }
 
           before { subject.service_provider.certs = [not_matching_cert, invalid_cert, cert] }
 
           it 'returns the matching cert' do
             expect(subject.matching_cert).to eq cert
-          end
-        end
-      end
-    end
-
-    describe '#sha256_validation_matching_cert' do
-      context 'when document is not signed' do
-        it 'returns nil' do
-          expect(subject.matching_cert).to be_nil
-        end
-      end
-
-      context 'when document is signed' do
-        let(:signed) { true }
-        let(:service_provider) { subject.service_provider }
-        let(:cert) { saml_settings.get_sp_cert }
-
-        describe 'the service provider has no registered certs' do
-          before { subject.service_provider.certs = [] }
-
-          it 'returns nil' do
-            expect(subject.sha256_validation_matching_cert).to be_nil
-          end
-        end
-
-        describe 'the service provider has one registered cert' do
-          before { subject.service_provider.certs = [cert] }
-
-          describe 'the cert matches the assertion cert' do
-            it 'returns the cert' do
-              expect(subject.sha256_validation_matching_cert).to eq cert
-            end
-
-            describe 'when the request is not embedded' do
-              let(:security_overrides) {{ embed_sign: false }}
-              let(:params) { encoded_request.symbolize_keys! }
-              subject { described_class.from_deflated_request(params[:SAMLRequest], get_params: params) }
-
-              it 'returns the cert' do
-                expect(subject.sha256_validation_matching_cert).to eq cert
-              end
-            end
-
-            context 'when the signature algorithm is not right' do
-              let(:security_overrides) do
-                {
-                  signature_method: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha1"
-                }
-              end
-
-              it 'returns nil' do
-                expect(subject.sha256_validation_matching_cert).to eq nil
-              end
-            end
-          end
-
-          describe 'the cert does not match the assertion cert' do
-            let(:cert) { OpenSSL::X509::Certificate.new(custom_idp_x509_cert) }
-
-            it 'returns nil' do
-              expect(subject.sha256_validation_matching_cert).to be_nil
-            end
-          end
-        end
-
-        describe 'multiple certs' do
-          let(:not_matching_cert) { OpenSSL::X509::Certificate.new(custom_idp_x509_cert) }
-
-          before { subject.service_provider.certs = [not_matching_cert, invalid_cert, cert] }
-
-          it 'returns the matching cert' do
-            expect(subject.sha256_validation_matching_cert).to eq cert
-          end
-
-          context 'when the signature algorithm is not right' do
-            let(:security_overrides) do
-              {
-                signature_method: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha1"
-              }
-            end
-
-            it 'returns nil' do
-              expect(subject.sha256_validation_matching_cert).to eq nil
-            end
           end
         end
       end
@@ -551,13 +467,14 @@ module SamlIdp
           before { subject.service_provider.certs = [] }
 
           it 'returns a no registered cert error' do
-            expect(subject.cert_errors).to eq [{cert: nil, error_code: :no_registered_certs}]
+            expect(subject.cert_errors).to eq [{ cert: nil, error_code: :no_registered_certs }]
           end
         end
 
         describe 'the service provider has one registered cert' do
           before { subject.service_provider.certs = [cert] }
-          let(:errors) { [{ cert: cert.serial.to_s, error_code: error_code }] }
+
+          let(:errors) { [{ cert: cert.serial.to_s, error_code: }] }
 
           describe 'the cert matches the assertion cert' do
             it 'returns nil' do
@@ -568,11 +485,7 @@ module SamlIdp
           describe 'the embedded certificate is bad' do
             let(:signed) { true }
             let(:local_overrides) { { certificate: invalid_cert.to_pem } }
-            let(:error_code) { :invalid_certificate_in_request }
-
-            before do
-              allow(OpenSSL::X509::Certificate).to receive(:new).and_raise OpenSSL::X509::CertificateError
-            end
+            let(:error_code) { :request_cert_not_registered }
 
             it 'returns an invalid certificate error' do
               expect(subject.cert_errors).to eq errors
@@ -581,7 +494,7 @@ module SamlIdp
 
           describe 'the cert element exists but is empty' do
             let(:error_code) { :no_certificate_in_request }
-            let(:errors) { [{ cert: nil, error_code: error_code }] }
+            let(:errors) { [{ cert: nil, error_code: }] }
             let(:blank_cert_element_req) do
               <<-XML.gsub(/^[\s]+|[\s]+\n/, '')
                 <?xml version="1.0"?>
@@ -627,8 +540,8 @@ module SamlIdp
 
           describe 'the cert does not match the assertion cert' do
             describe 'returns a fingerprint mismatch error' do
-              let(:cert) { OpenSSL::X509::Certificate.new(custom_idp_x509_cert) }
-              let(:error_code) { :fingerprint_mismatch }
+              let(:cert) { custom_cert }
+              let(:error_code) { :request_cert_not_registered }
 
               it 'returns nil' do
                 expect(subject.cert_errors).to eq errors
@@ -638,9 +551,10 @@ module SamlIdp
         end
 
         describe 'sp has multiple certs' do
-          let(:not_matching_cert) { OpenSSL::X509::Certificate.new(custom_idp_x509_cert) }
+          let(:not_matching_cert) { custom_cert }
 
           before { subject.service_provider.certs = [not_matching_cert, invalid_cert, cert] }
+
           describe 'there is a matching cert' do
             it 'returns nil' do
               expect(subject.cert_errors).to be_nil
@@ -652,12 +566,11 @@ module SamlIdp
 
             it 'returns multiple errors' do
               expected_errors = [
-                { cert: not_matching_cert.serial.to_s, error_code: :fingerprint_mismatch },
-                { cert: invalid_cert.serial.to_s, error_code: :fingerprint_mismatch },
+                { cert: not_matching_cert.serial.to_s, error_code: :request_cert_not_registered },
+                { cert: invalid_cert.serial.to_s, error_code: :request_cert_not_registered },
               ]
               expect(subject.cert_errors).to eq expected_errors
             end
-
           end
         end
       end

--- a/spec/support/certificate_helpers.rb
+++ b/spec/support/certificate_helpers.rb
@@ -10,9 +10,16 @@ module CertificateHelpers
   end
 
   def custom_idp_x509_cert_fingerprint
-    cert = OpenSSL::X509::Certificate.new(custom_idp_x509_cert)
-    digest = OpenSSL::Digest::SHA1.new(cert.to_der)
+    digest = OpenSSL::Digest::SHA1.new(custom_cert.to_der)
     digest.hexdigest.upcase.scan(/.{2}/).join(':')
+  end
+
+  def custom_cert
+    OpenSSL::X509::Certificate.new(custom_idp_x509_cert)
+  end
+
+  def default_cert
+    OpenSSL::X509::Certificate.new(Base64.decode64(saml_settings.certificate))
   end
 
   def encrypted_secret_key


### PR DESCRIPTION
This change is the follow-up to several weeks of tracking whether this change will [impact any existing integrations](https://github.com/18F/saml_idp/pull/126). [Running a query](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-1209600~timeType~'RELATIVE~tz~'LOCAL~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20name*20*3d*20*27SAML*20Auth*27*0a*7c*20filter*20properties.event_properties.certs_different*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2010000~queryId~'33d02f58-9385-440d-bf8f-95100245ed0e~source~(~'prod_*2fsrv*2fidp*2fshared*2flog*2fevents.log)~lang~'CWLI)) for the `certs_different` value does not produce any results, so it feels safe to move forward.

This change:
- Updates the `validate` path in the `XmlSecurity` class to stop messing around with trying to match digests; since we have the certs saved in the database, we can just compare those certs to the request cert.
- Allows the ValidationError for the wrong signature algorithm to be returned, rather than getting a more vague `fingerprint_mismatch` error.
- Eliminates some code that has become redundant based on the changes