### PR TITLE
Add explicit ostruct dependency to fix warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       builder
       faraday
       nokogiri (>= 1.10.2)
+      ostruct
       pkcs11
 
 GEM
@@ -163,6 +164,7 @@ GEM
     nokogiri (1.18.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    ostruct (0.6.1)
     parallel (1.24.0)
     parser (3.3.1.0)
       ast (~> 2.4.1)

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.23.5-18f'.freeze
+  VERSION = '0.23.6-18f'.freeze
 end

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency('faraday')
   s.add_dependency('nokogiri', '>= 1.10.2')
   s.add_dependency('pkcs11')
+  s.add_dependency('ostruct')
 
   s.add_development_dependency('capybara', '~> 3.40')
   s.add_development_dependency('listen')


### PR DESCRIPTION
- ostruct will not be loaded by default in Ruby 3.5

Example warning:
```
/srv/idp/shared/bundle/ruby/3.4.0/bundler/gems/saml_idp-bdf8e1f93707/lib/saml_idp/configurator.rb:1: warning: /opt/ruby_build/versions/3.4.1/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```