### PR TITLE
Provide SAML request validation errors in payload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.23.8.pre.18f)
+    saml_idp (0.23.9.pre.18f)
       activesupport
       builder
       faraday

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -21,11 +21,13 @@ module SamlIdp
 
       decode_request(raw_saml_request)
 
-      head :forbidden unless valid_saml_request?
+      unless valid_saml_request?
+        render json: { errors: saml_request.errors }, status: :bad_request
+      end
     rescue Nokogiri::XML::SyntaxError => e
       log 'Nokogiri::XML::SyntaxError validating request'
       log e
-      head :bad_request
+      render json: { errors: ["Invalid XML syntax: #{e}"] }, status: :bad_request
     end
 
     def decode_request(raw_saml_request)

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -21,13 +21,11 @@ module SamlIdp
 
       decode_request(raw_saml_request)
 
-      unless valid_saml_request?
-        render json: { errors: saml_request.errors }, status: :bad_request
-      end
+      valid_saml_request?
     rescue Nokogiri::XML::SyntaxError => e
       log 'Nokogiri::XML::SyntaxError validating request'
       log e
-      render json: { errors: ["Invalid XML syntax: #{e}"] }, status: :bad_request
+      head :bad_request
     end
 
     def decode_request(raw_saml_request)

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -119,7 +119,7 @@ module SamlIdp
 
       unless service_provider?
         log "Unable to find service provider for issuer #{issuer}"
-        errors.push(:issuer_missing_or_invald)
+        errors.push(:issuer_missing_or_invalid)
       end
 
       if authn_request? && logout_request?

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -137,7 +137,7 @@ module SamlIdp
         errors.push(:no_response_url)
       end
 
-      unless service_provider? && valid_signature?
+      if service_provider? && !valid_signature?
         log "Signature is invalid in #{raw_xml}"
         # TODO: We should get more specific errors
         errors.push(:invalid_signature)

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.23.8-18f'.freeze
+  VERSION = '0.23.9-18f'.freeze
 end

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -134,28 +134,23 @@ describe SamlIdp::Controller do
   end
 
   context 'invalid SAML Request' do
-    it 'returns a bad_request status with specific errors in the payload' do
+    it 'returns false' do
       params[:SAMLRequest] = custom_saml_request(overrides: {issuer: ''})
 
-      expect(self).to receive(:render).
-        with(json: { errors: [:issuer_missing_or_invalid, :invalid_signature] }, status: :bad_request)
-
-      validate_saml_request
+      expect(validate_saml_request).to eq false
     end
   end
 
   context 'invalid XML in SAML Request' do
     # This was encountered IRL on 2021-02-09
     before do
-      allow_any_instance_of(subject).to receive(:valid_saml_request?).
-        and_raise(Nokogiri::XML::SyntaxError.new("missing quotes"))
+      allow_any_instance_of(subject).to receive(:valid_saml_request?).and_raise(Nokogiri::XML::SyntaxError)
     end
 
-    it 'returns a bad_request status with specific errors in the payload' do
+    it 'returns headers only with a bad_request status' do
       params[:SAMLRequest] = custom_saml_request
 
-      expect(self).to receive(:render).
-        with(json: { errors: ["Invalid XML syntax: missing quotes"] }, status: :bad_request)
+      expect(self).to receive(:head).with(:bad_request)
 
       validate_saml_request
     end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -289,7 +289,7 @@ module SamlIdp
           it 'adds an error to the request object' do
             subject.valid?
 
-            expect(subject.errors.first).to eq :issuer_missing_or_invald
+            expect(subject.errors.first).to eq :issuer_missing_or_invalid
           end
         end
 

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -286,10 +286,10 @@ module SamlIdp
             expect(subject.valid?).to eq(false)
           end
 
-          it 'adds an error to the request object' do
+          it 'adds a single error to the request object' do
             subject.valid?
 
-            expect(subject.errors.first).to eq :issuer_missing_or_invalid
+            expect(subject.errors).to eq [:issuer_missing_or_invalid]
           end
         end
 


### PR DESCRIPTION
Previously, partners who sent an invalid SAML request would get a 403 and no other helpful information. In this PR, the errors are returned as a JSON payload, and the status is a bad request instead of a 403.

I also fixed a typo in the error for `issuer_missing_or_invalid`.

Before, a partner would see this in the browser:

<img width="1385" height="879" alt="Screenshot 2025-09-19 at 15 44 40" src="https://github.com/user-attachments/assets/d7adabdc-db1b-4d70-9910-8f64b77f9cc1" />


Now, they would see this:

<img width="1366" height="880" alt="Screenshot 2025-09-19 at 15 41 11" src="https://github.com/user-attachments/assets/85788113-909f-48bf-b86e-bd4f978818ba" />

For now, this is much more helpful, but we could improve this by rendering the error within our Login.gov website layout.