### PR TITLE
Update version number to match upcoming tag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.23.9.pre.18f)
+    saml_idp (0.23.10.pre.18f)
       activesupport
       builder
       faraday

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SAML IDP implementation.
 
 # For Login.gov maintainers
 
-When making a change to this gem, please remember to update the version number in `lib/saml_idp/version.rb`, and then run `bundle`. Once the version and Gemfile.lock changes have been committed and merged, run `script/release` from the `main` branch to create and push a new tag. Then, update the tag for the `saml_idp` gem in the `Gemfile` of the `idp` repo.
+When making a change to this gem, please remember to update the version number in `lib/saml_idp/version.rb`, and then run `bundle`. Once the version and Gemfile.lock changes have been committed and merged, run `script/release <version>` from the `main` branch to create and push a new tag. Then, update the tag for the `saml_idp` gem in the `Gemfile` of the `identity-idp` repo.
 
 # Installation and Usage
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ protocol. It provides a means for managing authentication requests and confirmat
 This was originally setup by @lawrencepit to test SAML Clients. I took it closer to a real
 SAML IDP implementation.
 
+# For Login.gov maintainers
+
+When making a change to this gem, please remember to update the version number in `lib/saml_idp/version.rb`, and then run `bundle`. Once the version and Gemfile.lock changes have been committed and merged, run `script/release` from the `main` branch to create and push a new tag. Then, update the tag for the `saml_idp` gem in the `Gemfile` of the `idp` repo.
+
 # Installation and Usage
 
 Add this to your Gemfile:

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.23.9-18f'.freeze
+  VERSION = '0.23.10-18f'.freeze
 end

--- a/script/release
+++ b/script/release
@@ -10,6 +10,7 @@ To tag a new release:
 EOF
 }
 
+# If no argument is provided to the script, print the usage instructions
 if [ $# -eq 0 ]; then
   print_help >&2
   exit 1
@@ -17,16 +18,20 @@ fi
 
 tag_name=""
 
+# If there is an argument, do the following depending on the argument
 while [ $# -gt 0 ]; do
   case "$1" in
+  # If the user ran "script/release --help" or "script/release -h", print the usage instructions
   -h | --help )
     print_help
     exit 0
     ;;
+  # If the user ran "script/release -t" or any other flag except -h, print an error
   -* )
     printf "unrecognized flag: %s\n" "$1" >&2
     exit 1
     ;;
+  # Otherwise, set the tag_name name variable to the argument
   * )
     tag_name="$1"
     shift 1

--- a/script/release
+++ b/script/release
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+print_help() {
+    cat <<EOF
+To tag a new release:
+  script/release <tag-name>
+  Example: script/release 0.23.10-18f
+EOF
+}
+
+if [ $# -eq 0 ]; then
+  print_help >&2
+  exit 1
+fi
+
+tag_name=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  -h | --help )
+    print_help
+    exit 0
+    ;;
+  -* )
+    printf "unrecognized flag: %s\n" "$1" >&2
+    exit 1
+    ;;
+  * )
+    tag_name="$1"
+    shift 1
+    ;;
+  esac
+done
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "refusing to continue due to uncommitted local changes" >&2
+  exit 1
+fi
+
+echo "Tagging version $tag_name and pushing to GitHub"
+echo ""
+
+git checkout main
+git pull
+git tag -s -m "Releasing $tag_name" v"$tag_name"
+git push origin main --tags
+
+echo ""
+echo "Done!"


### PR DESCRIPTION
The last time this gem was updated, the version number was not updated in `lib/saml_idp_version.rb`. This PR updates the version to match the upcoming `0.23.10-18f` tag that will be created after this PR is merged.

Also, I added a script to make it easier to create a new tag.