### PR TITLE
Remove requested_vtr_authn_contexts method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.24.10.pre.18f)
+    saml_idp (0.24.0.pre.18f)
       activesupport
       builder
       faraday

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.23.10.pre.18f)
+    saml_idp (0.24.10.pre.18f)
       activesupport
       builder
       faraday

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -2,8 +2,6 @@ require 'saml_idp/xml_security'
 require 'saml_idp/service_provider'
 module SamlIdp
   class Request
-    VTR_REGEXP = /\A[A-Z][a-z0-9](\.[A-Z][a-z0-9])*\z/
-
     def self.from_deflated_request(raw, options = {})
       if raw
         log "#{'~' * 20} RAW Request #{'~' * 20}\n#{raw}\n#{'~' * 18} Done RAW Request #{'~' * 17}\n"
@@ -80,12 +78,6 @@ module SamlIdp
         authn_context_nodes.map(&:content)
       else
         []
-      end
-    end
-
-    def requested_vtr_authn_contexts
-      requested_authn_contexts.select do |classref|
-        VTR_REGEXP.match?(classref)
       end
     end
 

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.24.10-18f'.freeze
+  VERSION = '0.24.0-18f'.freeze
 end

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.23.10-18f'.freeze
+  VERSION = '0.24.10-18f'.freeze
 end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 module SamlIdp
   describe Request do
     let(:ial) { 'http://idmanagement.gov/ns/assurance/ial/2' }
-    let(:vtr) { 'C1.C2.P1.Pb' }
     let(:authn_context_classref) { 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password' }
     let(:issuer) { 'localhost:3000' }
     let(:local_overrides) { {} }
@@ -210,60 +209,6 @@ module SamlIdp
 
       it 'returns logout_url for response_url' do
         expect(subject.response_url).to eq(subject.logout_url)
-      end
-    end
-
-    describe '#requested_vtr_authn_contexts' do
-      subject { described_class.from_deflated_request encoded_request }
-
-      context 'no vtr context requested' do
-        let(:authn_context_classref) { '' }
-
-        it 'returns an empty array' do
-          expect(subject.requested_vtr_authn_contexts).to eq([])
-        end
-      end
-
-      context 'only vtr is requested' do
-        let(:authn_context_classref) { vtr }
-
-        it 'returns the vrt' do
-          expect(subject.requested_vtr_authn_contexts).to eq([vtr])
-        end
-      end
-
-      context 'multiple contexts including vtr and an old ACR context' do
-        let(:authn_context_classref) { [vtr, ial] }
-
-        it 'returns the vrt' do
-          expect(subject.requested_vtr_authn_contexts).to eq([vtr])
-        end
-      end
-
-      context 'multiple contexts that are vectors of trust' do
-        let(:authn_context_classref) { [vtr, 'C1.C2.P1'] }
-
-        it 'returns all of the vectors in an array' do
-          expect(subject.requested_vtr_authn_contexts).to eq([vtr, 'C1.C2.P1'])
-        end
-      end
-
-      context 'context that contains a VTR substring but is not a VTR' do
-        let(:authn_context_classref) do
-          'Not a VTR but does contain LetT3.Rs and Nu.Mb.Ers'
-        end
-
-        it 'does not match on the context' do
-          expect(subject.requested_vtr_authn_contexts).to eq([])
-        end
-      end
-
-      context 'with the default MFA context' do
-        let(:authn_context_classref) { 'urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo' }
-
-        it 'does not match on the context' do
-          expect(subject.requested_vtr_authn_contexts).to eq([])
-        end
       end
     end
 


### PR DESCRIPTION
Part 4 of removing VoT from the IdP, following up on https://github.com/18F/identity-idp/pull/12741

- [x] Removing Vectors of Trust code from the OIDC flow (https://github.com/18F/identity-idp/pull/12718).
- [x] Removing VoT code from SAML flow (https://github.com/18F/identity-idp/pull/12721)
- [x] Remove references to VoT from the AuthnContextResolver, as well as the references to the Vectors themselves. (https://github.com/18F/identity-idp/pull/12741_)
- [x] Removing VoT from the saml_idp gem (this PR)
- [ ] Renaming files so that all references to VoT will be removed, removing related configuration code. (except perhaps some specs that ensure it is not a valid code flow)