### PR TITLE
Unpin activesupport to address version constraint mismatch downstream

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.24.1.pre.18f)
-      activesupport (~> 7.2.3)
+    saml_idp (0.24.2.pre.18f)
+      activesupport
       builder
       faraday (>= 2.14.1)
       nokogiri (>= 1.19.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     saml_idp (0.24.2.pre.18f)
-      activesupport
+      activesupport (>= 7.2.3)
       builder
       faraday (>= 2.14.1)
       nokogiri (>= 1.19.4)

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.24.1-18f'.freeze
+  VERSION = '0.24.2-18f'.freeze
 end

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.3.4'
 
-  s.add_dependency('activesupport')
+  s.add_dependency('activesupport', '>= 7.2.3')
   s.add_dependency('builder')
   s.add_dependency('faraday', '>= 2.14.1')
   s.add_dependency('nokogiri', '>= 1.19.4')

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.3.4'
 
-  s.add_dependency('activesupport', '~> 7.2.3')
+  s.add_dependency('activesupport')
   s.add_dependency('builder')
   s.add_dependency('faraday', '>= 2.14.1')
   s.add_dependency('nokogiri', '>= 1.19.4')


### PR DESCRIPTION
Updating the identity-idp to use the last tagged version failed with:

```
And because actionview >= 8.1.3 depends on activesupport = 8.1.3
  and actionview < 8.1.0 depends on activesupport = 8.0.5,
  activesupport = 8.0.5 OR = 8.1.0 OR = 8.1.1 OR = 8.1.2 OR = 8.1.2.1 OR = 8.1.3 is required.
So, because every version of saml_idp depends on activesupport ~> 7.2.3
  and Gemfile depends on saml_idp >= 0,
  version solving has failed.
  ```

this change removes the active pinning in the gemspec to resolve the constraint mismatch.