### PR TITLE
Pipe AuthnInstant value

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    saml_idp (0.24.2.pre.18f)
+    saml_idp (0.25.2.pre.18f)
       activesupport (>= 7.2.3)
       builder
       faraday (>= 2.14.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.7)
     connection_pool (2.4.1)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     diff-lcs (1.5.1)
     docile (1.4.0)
@@ -297,7 +297,8 @@ GEM
     uri (0.13.3)
     useragent (0.16.11)
     webrick (1.8.2)
-    websocket-driver (0.7.6)
+    websocket-driver (0.8.2)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xmlenc (0.8.0)

--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -7,7 +7,8 @@ module SamlIdp
     include Signable
     attr_accessor :reference_id
     attr_accessor :issuer_uri, :principal, :audience_uri, :saml_request_id, :saml_acs_url,
-                  :raw_algorithm, :authn_context_classref, :name_id_format, :expiry, :encryption_opts
+                  :raw_algorithm, :authn_context_classref, :name_id_format, :expiry,
+                  :encryption_opts, :authn_instant
 
     delegate :config, to: :SamlIdp
 
@@ -24,6 +25,7 @@ module SamlIdp
       name_id_format,
       x509_certificate,
       secret_key,
+      authn_instant,
       expiry = 60 * 60,
       encryption_opts = nil
     )
@@ -37,6 +39,7 @@ module SamlIdp
       self.raw_algorithm = raw_algorithm
       self.authn_context_classref = authn_context_classref
       self.name_id_format = name_id_format
+      self.authn_instant = authn_instant
       self.x509_certificate = x509_certificate
       self.secret_key = secret_key
       self.expiry = expiry
@@ -80,7 +83,7 @@ module SamlIdp
             end
           end
         end
-        assertion.AuthnStatement AuthnInstant: now_iso,
+        assertion.AuthnStatement AuthnInstant: iso { authn_instant.utc },
                                  SessionIndex: reference_string do |statement|
           statement.AuthnContext do |context|
             case authn_context_classref

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -47,6 +47,7 @@ module SamlIdp
       encryption_opts = opts[:encryption] || nil
       signature_opts = opts[:signature] || {}
       response_name_id_format = opts[:name_id_format] || saml_request.name_id_format
+      authn_instant = opts[:authn_instant] || Time.zone.now
 
       response = SamlResponse.new(
         reference_id,
@@ -59,6 +60,7 @@ module SamlIdp
         (opts[:algorithm] || algorithm || default_algorithm),
         my_authn_context_classref,
         response_name_id_format,
+        authn_instant,
         signature_opts[:x509_certificate],
         signature_opts[:secret_key],
         expiry,
@@ -82,7 +84,7 @@ module SamlIdp
         saml_request_id,
         (opts[:algorithm] || algorithm || default_algorithm),
         signature_opts[:x509_certificate],
-        signature_opts[:secret_key],
+        signature_opts[:secret_key]
       ).raw
     end
 

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -4,7 +4,7 @@ module SamlIdp
   class SamlResponse
     attr_accessor :assertion_with_signature, :reference_id, :response_id, :issuer_uri, :principal,
                   :audience_uri, :saml_request_id, :saml_acs_url, :algorithm,
-                  :authn_context_classref, :name_id_format, :x509_certificate, :secret_key,
+                  :authn_context_classref, :name_id_format, :authn_instant, :x509_certificate, :secret_key,
                   :expiry, :encryption_opts
 
     # rubocop:disable Metrics/ParameterLists
@@ -19,6 +19,7 @@ module SamlIdp
       algorithm,
       authn_context_classref,
       name_id_format,
+      authn_instant,
       x509_certificate = nil,
       secret_key = nil,
       expiry = 60 * 60,
@@ -34,6 +35,7 @@ module SamlIdp
       self.saml_acs_url = saml_acs_url
       self.algorithm = algorithm
       self.secret_key = secret_key
+      self.authn_instant = authn_instant
       self.x509_certificate = x509_certificate
       self.authn_context_classref = authn_context_classref
       self.name_id_format = name_id_format
@@ -42,7 +44,7 @@ module SamlIdp
     end
 
     def build
-      @built ||= response_builder.encoded
+      @build ||= response_builder.encoded
     end
 
     def signed
@@ -67,7 +69,7 @@ module SamlIdp
         signed_assertion,
         algorithm,
         x509_certificate,
-        secret_key,
+        secret_key
       )
     end
     private :response_builder
@@ -85,6 +87,7 @@ module SamlIdp
         name_id_format,
         x509_certificate,
         secret_key,
+        authn_instant,
         expiry,
         encryption_opts
       )

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,3 +1,3 @@
 module SamlIdp
-  VERSION = '0.24.2-18f'.freeze
+  VERSION = '0.25.2-18f'.freeze
 end

--- a/spec/lib/saml_idp/assertion_builder_spec.rb
+++ b/spec/lib/saml_idp/assertion_builder_spec.rb
@@ -82,7 +82,6 @@ module SamlIdp
           authn_instant,
           expiry
         )
-        # expected_authn_instant =
         Timecop.travel(Time.zone.local(2010, 6, 1, 13, 0, 0)) do
           raw = '<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_abc" IssueInstant="2010-06-01T13:00:00Z" Version="2.0"><Issuer>http://sportngin.com</Issuer><Subject><NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">foo@example.com</NameID><SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData InResponseTo="123" NotOnOrAfter="2010-06-01T13:03:00Z" Recipient="http://saml.acs.url"></SubjectConfirmationData></SubjectConfirmation></Subject><Conditions NotBefore="2010-06-01T12:59:55Z" NotOnOrAfter="2010-06-01T16:00:00Z"><AudienceRestriction><Audience>http://example.com</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name="emailAddress" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="emailAddress"><AttributeValue>foo@example.com</AttributeValue></Attribute></AttributeStatement><AuthnStatement AuthnInstant="'
           raw += authn_instant.iso8601

--- a/spec/lib/saml_idp/assertion_builder_spec.rb
+++ b/spec/lib/saml_idp/assertion_builder_spec.rb
@@ -20,6 +20,7 @@ module SamlIdp
         key_transport: 'rsa-oaep-mgf1p',
       }
     end
+    let(:authn_instant) { Time.zone.now }
 
     subject do
       described_class.new(
@@ -34,6 +35,7 @@ module SamlIdp
         name_id_format,
         nil,
         nil,
+        authn_instant,
         expiry
       )
     end
@@ -77,10 +79,15 @@ module SamlIdp
           name_id_format,
           nil,
           nil,
+          authn_instant,
           expiry
         )
+        # expected_authn_instant =
         Timecop.travel(Time.zone.local(2010, 6, 1, 13, 0, 0)) do
-          expect(builder.raw).to eq('<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_abc" IssueInstant="2010-06-01T13:00:00Z" Version="2.0"><Issuer>http://sportngin.com</Issuer><Subject><NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">foo@example.com</NameID><SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData InResponseTo="123" NotOnOrAfter="2010-06-01T13:03:00Z" Recipient="http://saml.acs.url"></SubjectConfirmationData></SubjectConfirmation></Subject><Conditions NotBefore="2010-06-01T12:59:55Z" NotOnOrAfter="2010-06-01T16:00:00Z"><AudienceRestriction><Audience>http://example.com</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name="emailAddress" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="emailAddress"><AttributeValue>foo@example.com</AttributeValue></Attribute></AttributeStatement><AuthnStatement AuthnInstant="2010-06-01T13:00:00Z" SessionIndex="_abc"><AuthnContext><AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</AuthnContextClassRef></AuthnContext></AuthnStatement></Assertion>')
+          raw = '<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_abc" IssueInstant="2010-06-01T13:00:00Z" Version="2.0"><Issuer>http://sportngin.com</Issuer><Subject><NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">foo@example.com</NameID><SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><SubjectConfirmationData InResponseTo="123" NotOnOrAfter="2010-06-01T13:03:00Z" Recipient="http://saml.acs.url"></SubjectConfirmationData></SubjectConfirmation></Subject><Conditions NotBefore="2010-06-01T12:59:55Z" NotOnOrAfter="2010-06-01T16:00:00Z"><AudienceRestriction><Audience>http://example.com</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name="emailAddress" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="emailAddress"><AttributeValue>foo@example.com</AttributeValue></Attribute></AttributeStatement><AuthnStatement AuthnInstant="'
+          raw += authn_instant.iso8601
+          raw += '" SessionIndex="_abc"><AuthnContext><AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</AuthnContextClassRef></AuthnContext></AuthnStatement></Assertion>'
+          expect(builder.raw).to eq(raw)
         end
       end
     end
@@ -98,6 +105,7 @@ module SamlIdp
         name_id_format,
         nil,
         nil,
+        authn_instant,
         expiry,
         encryption_opts
       )

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -24,6 +24,8 @@ module SamlIdp
         key_transport: 'rsa-oaep-mgf1p',
       }
     end
+    let(:authn_instant) { Time.zone.now }
+
     let(:subject_encrypted) do
       described_class.new(reference_id,
                           response_id,
@@ -35,6 +37,7 @@ module SamlIdp
                           algorithm,
                           authn_context_classref,
                           name_id_format,
+                          authn_instant,
                           nil,
                           nil,
                           expiry,
@@ -52,6 +55,7 @@ module SamlIdp
                           algorithm,
                           authn_context_classref,
                           name_id_format,
+                          authn_instant,
                           nil,
                           nil,
                           expiry)
@@ -102,6 +106,7 @@ module SamlIdp
                             algorithm,
                             authn_context_classref,
                             name_id_format,
+                            authn_instant,
                             custom_idp_x509_cert,
                             custom_idp_secret_key,
                             expiry,


### PR DESCRIPTION
this change:

- pipes the authn_instant value through so that it can be added to the assertion
- updates specs
- updates vulnerabilities
- updates version number